### PR TITLE
[ETFE-3938] Add incomplete tag and continue link to Transport Units Add to List

### DIFF
--- a/app/models/sections/transportUnit/TransportUnitsAddToListModel.scala
+++ b/app/models/sections/transportUnit/TransportUnitsAddToListModel.scala
@@ -16,10 +16,15 @@
 
 package models.sections.transportUnit
 
+import models.requests.DataRequest
 import models.{Enumerable, WithName}
+import pages.sections.transportUnit.TransportUnitsSectionUnits
 import play.api.i18n.Messages
+import queries.TransportUnitsCount
 import uk.gov.hmrc.govukfrontend.views.Aliases.Text
 import uk.gov.hmrc.govukfrontend.views.viewmodels.radios.RadioItem
+import viewmodels.taskList.InProgress
+import views.ViewUtils.pluralSingular
 
 sealed trait TransportUnitsAddToListModel
 
@@ -35,9 +40,18 @@ object TransportUnitsAddToListModel extends Enumerable.Implicits {
     Yes, MoreToCome, NoMoreToCome
   )
 
-  def options(implicit messages: Messages): Seq[RadioItem] = {
+  def options(implicit messages: Messages, request: DataRequest[_]): Seq[RadioItem] = {
+
+    val showNoOption = TransportUnitsSectionUnits.status != InProgress
+
+    val numberOfTransportUnits = request.userAnswers.get(TransportUnitsCount).getOrElse(0)
+
     def radioItem(value: TransportUnitsAddToListModel, index: Int): RadioItem = RadioItem(
-      content = Text(messages(s"transportUnitsAddToList.${value.toString}")),
+      content = if (index == 1) {
+        Text(pluralSingular(s"transportUnitsAddToList.${value.toString}", numberOfTransportUnits))
+      } else {
+        Text(messages(s"transportUnitsAddToList.${value.toString}"))
+      },
       value = Some(value.toString),
       id = Some(s"value_$index")
     )
@@ -47,11 +61,11 @@ object TransportUnitsAddToListModel extends Enumerable.Implicits {
     )
 
     Seq(
-      radioItem(Yes, 0),
-      radioItem(NoMoreToCome, 1),
-      orDivider,
-      radioItem(MoreToCome, 2)
-    )
+      Some(radioItem(Yes, 0)),
+      if (showNoOption) Some(radioItem(NoMoreToCome, 1)) else None,
+      if (showNoOption) Some(orDivider) else None,
+      Some(radioItem(MoreToCome, 2))
+    ).flatten
   }
 
   implicit val enumerable: Enumerable[TransportUnitsAddToListModel] =

--- a/app/pages/sections/transportUnit/TransportSealTypePage.scala
+++ b/app/pages/sections/transportUnit/TransportSealTypePage.scala
@@ -29,12 +29,5 @@ case class TransportSealTypePage(idx: Index) extends QuestionPage[TransportSealT
   override val toString: String = "transportSealType"
   override val path: JsPath = TransportUnitSection(idx).path \ toString
 
-  override def getValueFromIE801(implicit request: DataRequest[_]): Option[TransportSealTypeModel] =
-    ifIndexIsValid(TransportUnitsCount, idx)(valueIfIndexIsValid = Try {
-      val transportDetails = request.movementDetails.transportDetails(idx.position)
-      transportDetails.commercialSealIdentification.map {
-        identification =>
-          TransportSealTypeModel(identification, transportDetails.sealInformation)
-      }
-    }.getOrElse(None)) // In case the number of transport units in user answers exceeds the number of TU's in 801 (return None as out of bounds)
+  override def getValueFromIE801(implicit request: DataRequest[_]): Option[TransportSealTypeModel] = None
 }

--- a/app/pages/sections/transportUnit/TransportUnitGiveMoreInformationPage.scala
+++ b/app/pages/sections/transportUnit/TransportUnitGiveMoreInformationPage.scala
@@ -28,8 +28,5 @@ case class TransportUnitGiveMoreInformationPage(idx: Index) extends QuestionPage
   override val toString: String = "transportUnitGiveMoreInformation"
   override val path: JsPath = TransportUnitSection(idx).path \ toString
 
-  override def getValueFromIE801(implicit request: DataRequest[_]): Option[Option[String]] =
-    ifIndexIsValid(TransportUnitsCount, idx)(valueIfIndexIsValid = Try {
-      Some(request.movementDetails.transportDetails(idx.position).complementaryInformation)
-    }.getOrElse(None)) // In case the number of transport units in user answers exceeds the number of TU's in 801 (return None as out of bounds)
+  override def getValueFromIE801(implicit request: DataRequest[_]): Option[Option[String]] = None
 }

--- a/app/pages/sections/transportUnit/TransportUnitIdentityPage.scala
+++ b/app/pages/sections/transportUnit/TransportUnitIdentityPage.scala
@@ -28,8 +28,5 @@ case class TransportUnitIdentityPage(idx: Index) extends QuestionPage[String] {
   override val toString: String = "transportUnitIdentity"
   override val path: JsPath = TransportUnitSection(idx).path \ toString
 
-  override def getValueFromIE801(implicit request: DataRequest[_]): Option[String] =
-    ifIndexIsValid(TransportUnitsCount, idx)(valueIfIndexIsValid = Try {
-      request.movementDetails.transportDetails(idx.position).identityOfTransportUnits
-    }.getOrElse(None)) // In case the number of transport units in user answers exceeds the number of TU's in 801 (return None as out of bounds)
+  override def getValueFromIE801(implicit request: DataRequest[_]): Option[String] = None
 }

--- a/app/pages/sections/transportUnit/TransportUnitTypePage.scala
+++ b/app/pages/sections/transportUnit/TransportUnitTypePage.scala
@@ -29,10 +29,5 @@ case class TransportUnitTypePage(idx: Index) extends QuestionPage[TransportUnitT
   override val toString: String = "transportUnitType"
   override val path: JsPath = TransportUnitSection(idx).path \ toString
 
-  override def getValueFromIE801(implicit request: DataRequest[_]): Option[TransportUnitType] = {
-    // TODO: check
-    ifIndexIsValid(TransportUnitsCount, idx)(valueIfIndexIsValid = Try {
-      JsString(request.movementDetails.transportDetails(idx.position).transportUnitCode).asOpt[TransportUnitType]
-    }.getOrElse(None)) // In case the number of transport units in user answers exceeds the number of TU's in 801 (return None as out of bounds)
-  }
+  override def getValueFromIE801(implicit request: DataRequest[_]): Option[TransportUnitType] = None
 }

--- a/app/viewmodels/checkAnswers/sections/transportUnit/TransportSealChoiceSummary.scala
+++ b/app/viewmodels/checkAnswers/sections/transportUnit/TransportSealChoiceSummary.scala
@@ -27,11 +27,11 @@ import viewmodels.implicits._
 
 object TransportSealChoiceSummary {
 
-  def row(idx: Index, onReviewPage: Boolean)(implicit request: DataRequest[_], messages: Messages): SummaryListRow =
+  def row(idx: Index, hideChangeLinks: Boolean)(implicit request: DataRequest[_], messages: Messages): SummaryListRow =
     SummaryListRowViewModel(
       key = "transportSealChoice.checkYourAnswersLabel",
       value = ValueViewModel(getValue(idx)),
-      actions = if(onReviewPage) Seq() else Seq(
+      actions = if(hideChangeLinks) Seq() else Seq(
         ActionItemViewModel(
           content = "site.change",
           href = controllers.sections.transportUnit.routes.TransportSealChoiceController.onPageLoad(request.userAnswers.ern, request.userAnswers.arc, idx, CheckMode).url,

--- a/app/viewmodels/checkAnswers/sections/transportUnit/TransportSealChoiceSummary.scala
+++ b/app/viewmodels/checkAnswers/sections/transportUnit/TransportSealChoiceSummary.scala
@@ -27,19 +27,18 @@ import viewmodels.implicits._
 
 object TransportSealChoiceSummary {
 
-  def row(idx: Index, onReviewPage: Boolean)(implicit request: DataRequest[_], messages: Messages): Option[SummaryListRow] =
-    Some(
-      SummaryListRowViewModel(
-        key = "transportSealChoice.checkYourAnswersLabel",
-        value = ValueViewModel(getValue(idx)),
-        actions = if(onReviewPage) Seq() else Seq(
-          ActionItemViewModel(
-            content = "site.change",
-            href = controllers.sections.transportUnit.routes.TransportSealChoiceController.onPageLoad(request.userAnswers.ern, request.userAnswers.arc, idx, CheckMode).url,
-            id = s"changeTransportSealChoice${idx.displayIndex}")
-            .withVisuallyHiddenText(messages("transportSealChoice.change.hidden"))
-        )
-      ))
+  def row(idx: Index, onReviewPage: Boolean)(implicit request: DataRequest[_], messages: Messages): SummaryListRow =
+    SummaryListRowViewModel(
+      key = "transportSealChoice.checkYourAnswersLabel",
+      value = ValueViewModel(getValue(idx)),
+      actions = if(onReviewPage) Seq() else Seq(
+        ActionItemViewModel(
+          content = "site.change",
+          href = controllers.sections.transportUnit.routes.TransportSealChoiceController.onPageLoad(request.userAnswers.ern, request.userAnswers.arc, idx, CheckMode).url,
+          id = s"changeTransportSealChoice${idx.displayIndex}")
+          .withVisuallyHiddenText(messages("transportSealChoice.change.hidden"))
+      )
+    )
 
 
   private def getValue(idx: Index)(implicit request: DataRequest[_], messages: Messages): Content =

--- a/app/viewmodels/checkAnswers/sections/transportUnit/TransportSealInformationSummary.scala
+++ b/app/viewmodels/checkAnswers/sections/transportUnit/TransportSealInformationSummary.scala
@@ -30,13 +30,13 @@ import viewmodels.implicits._
 
 object TransportSealInformationSummary {
 
-  def row(idx: Index, onReviewPage: Boolean)(implicit request: DataRequest[_], messages: Messages, link: views.html.components.link): Option[SummaryListRow] = {
+  def row(idx: Index, hideChangeLinks: Boolean)(implicit request: DataRequest[_], messages: Messages, link: views.html.components.link): Option[SummaryListRow] = {
     request.userAnswers.get(TransportSealChoicePage(idx)).filter(identity).map { _ =>
       request.userAnswers.get(TransportSealTypePage(idx)) match {
         case Some(TransportSealTypeModel(_, Some(info))) => SummaryListRowViewModel(
           key = "transportSealType.moreInfo.checkYourAnswersLabel",
           value = ValueViewModel(info),
-          actions = if(onReviewPage) Seq() else Seq(
+          actions = if(hideChangeLinks) Seq() else Seq(
             ActionItemViewModel(
               "site.change",
               routes.TransportSealTypeController.onPageLoad(request.userAnswers.ern, request.userAnswers.arc, idx, CheckMode).url,
@@ -45,7 +45,7 @@ object TransportSealInformationSummary {
           )
         )
         case _ =>
-          val summaryRowValue = if(onReviewPage) Text(messages("site.notProvided")) else HtmlContent(link(
+          val summaryRowValue = if(hideChangeLinks) Text(messages("site.notProvided")) else HtmlContent(link(
             link = routes.TransportSealTypeController.onPageLoad(request.userAnswers.ern, request.userAnswers.arc, idx, CheckMode).url,
             messageKey = s"transportSealType.moreInfo.checkYourAnswersAddInfo"))
           SummaryListRowViewModel(

--- a/app/viewmodels/checkAnswers/sections/transportUnit/TransportSealTypeSummary.scala
+++ b/app/viewmodels/checkAnswers/sections/transportUnit/TransportSealTypeSummary.scala
@@ -28,12 +28,12 @@ import viewmodels.implicits._
 
 object TransportSealTypeSummary {
 
-  def row(idx: Index, onReviewPage: Boolean)(implicit request: DataRequest[_], messages: Messages): Option[SummaryListRow] = {
+  def row(idx: Index, hideChangeLinks: Boolean)(implicit request: DataRequest[_], messages: Messages): Option[SummaryListRow] = {
     request.userAnswers.get(TransportSealChoicePage(idx)).filter(identity).map { _ =>
       SummaryListRowViewModel(
         key = "transportSealType.sealType.checkYourAnswersLabel",
         value = ValueViewModel(getValue(idx)),
-        actions = if(onReviewPage) Seq() else Seq(
+        actions = if(hideChangeLinks) Seq() else Seq(
           ActionItemViewModel(
             "site.change",
             routes.TransportSealTypeController.onPageLoad(request.userAnswers.ern, request.userAnswers.arc, idx, CheckMode).url,

--- a/app/viewmodels/checkAnswers/sections/transportUnit/TransportUnitGiveMoreInformationSummary.scala
+++ b/app/viewmodels/checkAnswers/sections/transportUnit/TransportUnitGiveMoreInformationSummary.scala
@@ -30,9 +30,9 @@ import viewmodels.implicits._
 
 object TransportUnitGiveMoreInformationSummary {
 
-  def row(idx: Index, onReviewPage: Boolean)(implicit request: DataRequest[_], messages: Messages, link: views.html.components.link): Option[SummaryListRow] = {
+  def row(idx: Index, onReviewPage: Boolean)(implicit request: DataRequest[_], messages: Messages, link: views.html.components.link): SummaryListRow = {
     val optMoreInformation = request.userAnswers.get(TransportUnitGiveMoreInformationPage(idx)).flatten
-    Some(SummaryListRowViewModel(
+    SummaryListRowViewModel(
       key = "transportUnitGiveMoreInformation.checkYourAnswersLabel",
       value = ValueViewModel(getValue(optMoreInformation,
         controllers.sections.transportUnit.routes.TransportUnitGiveMoreInformationController.onPageLoad(request.userAnswers.ern, request.userAnswers.arc, idx, CheckMode), onReviewPage)),
@@ -47,7 +47,7 @@ object TransportUnitGiveMoreInformationSummary {
           )
         ).flatten
       }
-    ))
+    )
   }
 
   private def getValue(optValue: Option[String], redirectUrl: Call, onReviewPage: Boolean)

--- a/app/viewmodels/checkAnswers/sections/transportUnit/TransportUnitGiveMoreInformationSummary.scala
+++ b/app/viewmodels/checkAnswers/sections/transportUnit/TransportUnitGiveMoreInformationSummary.scala
@@ -30,13 +30,13 @@ import viewmodels.implicits._
 
 object TransportUnitGiveMoreInformationSummary {
 
-  def row(idx: Index, onReviewPage: Boolean)(implicit request: DataRequest[_], messages: Messages, link: views.html.components.link): SummaryListRow = {
+  def row(idx: Index, hideChangeLinks: Boolean)(implicit request: DataRequest[_], messages: Messages, link: views.html.components.link): SummaryListRow = {
     val optMoreInformation = request.userAnswers.get(TransportUnitGiveMoreInformationPage(idx)).flatten
     SummaryListRowViewModel(
       key = "transportUnitGiveMoreInformation.checkYourAnswersLabel",
       value = ValueViewModel(getValue(optMoreInformation,
-        controllers.sections.transportUnit.routes.TransportUnitGiveMoreInformationController.onPageLoad(request.userAnswers.ern, request.userAnswers.arc, idx, CheckMode), onReviewPage)),
-      actions = if(onReviewPage) Seq() else {
+        controllers.sections.transportUnit.routes.TransportUnitGiveMoreInformationController.onPageLoad(request.userAnswers.ern, request.userAnswers.arc, idx, CheckMode), hideChangeLinks)),
+      actions = if(hideChangeLinks) Seq() else {
         Seq(
           optMoreInformation.map(_ =>
             ActionItemViewModel(
@@ -50,10 +50,10 @@ object TransportUnitGiveMoreInformationSummary {
     )
   }
 
-  private def getValue(optValue: Option[String], redirectUrl: Call, onReviewPage: Boolean)
+  private def getValue(optValue: Option[String], redirectUrl: Call, hideChangeLinks: Boolean)
                       (implicit messages: Messages, link: views.html.components.link): Content =
     optValue.fold[Content]({
-      if(onReviewPage) {
+      if(hideChangeLinks) {
         Text(messages("site.notProvided"))
       } else {
         HtmlContent(link(redirectUrl.url, messages("transportUnitGiveMoreInformation.checkYourAnswersValue")))

--- a/app/viewmodels/checkAnswers/sections/transportUnit/TransportUnitIdentitySummary.scala
+++ b/app/viewmodels/checkAnswers/sections/transportUnit/TransportUnitIdentitySummary.scala
@@ -29,8 +29,8 @@ import viewmodels.implicits._
 
 object TransportUnitIdentitySummary {
 
-  def row(idx: Index, onReviewPage: Boolean)(implicit request: DataRequest[_], messages: Messages): Option[SummaryListRow] =
-    Some(SummaryListRowViewModel(
+  def row(idx: Index, onReviewPage: Boolean)(implicit request: DataRequest[_], messages: Messages): SummaryListRow =
+    SummaryListRowViewModel(
       key = "transportUnitIdentity.checkYourAnswersLabel",
       value = ValueViewModel(getValue(idx)),
       actions = if(onReviewPage) Seq() else Seq(
@@ -40,7 +40,7 @@ object TransportUnitIdentitySummary {
           s"changeTransportUnitIdentity${idx.displayIndex}"
         ).withVisuallyHiddenText(messages("transportUnitIdentity.change.hidden"))
       )
-    ))
+    )
 
   private def getValue(idx: Index)(implicit request: DataRequest[_], messages: Messages): Content =
     request.userAnswers.get(TransportUnitIdentityPage(idx)).fold(Text(messages("site.notProvided")))(answer => HtmlFormat.escape(answer).toString())

--- a/app/viewmodels/checkAnswers/sections/transportUnit/TransportUnitIdentitySummary.scala
+++ b/app/viewmodels/checkAnswers/sections/transportUnit/TransportUnitIdentitySummary.scala
@@ -29,11 +29,11 @@ import viewmodels.implicits._
 
 object TransportUnitIdentitySummary {
 
-  def row(idx: Index, onReviewPage: Boolean)(implicit request: DataRequest[_], messages: Messages): SummaryListRow =
+  def row(idx: Index, hideChangeLinks: Boolean)(implicit request: DataRequest[_], messages: Messages): SummaryListRow =
     SummaryListRowViewModel(
       key = "transportUnitIdentity.checkYourAnswersLabel",
       value = ValueViewModel(getValue(idx)),
-      actions = if(onReviewPage) Seq() else Seq(
+      actions = if(hideChangeLinks) Seq() else Seq(
         ActionItemViewModel(
           "site.change",
           routes.TransportUnitIdentityController.onPageLoad(request.userAnswers.ern, request.userAnswers.arc, idx, CheckMode).url,

--- a/app/viewmodels/checkAnswers/sections/transportUnit/TransportUnitTypeSummary.scala
+++ b/app/viewmodels/checkAnswers/sections/transportUnit/TransportUnitTypeSummary.scala
@@ -27,13 +27,13 @@ import viewmodels.implicits._
 
 object TransportUnitTypeSummary {
 
-  def row(idx: Index, onReviewPage: Boolean)(implicit request: DataRequest[_], messages: Messages): Option[SummaryListRow] =
+  def row(idx: Index, hideChangeLinks: Boolean)(implicit request: DataRequest[_], messages: Messages): Option[SummaryListRow] =
     request.userAnswers.get(TransportUnitTypePage(idx)).map {
       answer =>
         SummaryListRowViewModel(
           key = "transportUnitType.addToListLabel",
           value = ValueViewModel(messages(s"transportUnitType.$answer")),
-          actions = if(onReviewPage) Seq() else Seq(
+          actions = if(hideChangeLinks) Seq() else Seq(
             ActionItemViewModel(
               "site.change",
               routes.TransportUnitTypeController.onPageLoad(request.userAnswers.ern, request.userAnswers.arc, idx, CheckMode).url,

--- a/app/viewmodels/helpers/TagHelper.scala
+++ b/app/viewmodels/helpers/TagHelper.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package viewmodels.helpers
+
+import play.api.i18n.Messages
+import play.twirl.api.Html
+import viewmodels.taskList.UpdateNeeded
+
+import javax.inject.{Inject, Singleton}
+
+@Singleton
+class TagHelper @Inject()(tag: views.html.components.tag) {
+
+  def updateNeededTag(withNoFloat: Boolean = true)(implicit messages: Messages): Html = tag(
+    message = messages(UpdateNeeded.msgKey),
+    colour = "orange",
+    extraClasses = if (withNoFloat) "float-none govuk-!-margin-left-1" else ""
+  )
+
+  def incompleteTag()(implicit messages: Messages): Html = tag(
+    message = messages("taskListStatus.incomplete"),
+    colour = "red"
+  )
+
+}

--- a/app/viewmodels/helpers/TransportUnitsAddToListHelper.scala
+++ b/app/viewmodels/helpers/TransportUnitsAddToListHelper.scala
@@ -17,20 +17,24 @@
 package viewmodels.helpers
 
 import controllers.sections.transportUnit.{routes => transportUnitRoutes}
-import models.Index
 import models.requests.DataRequest
 import models.sections.transportUnit.TransportUnitType.FixedTransport
-import pages.sections.transportUnit.TransportUnitTypePage
+import models.{Index, NormalMode}
+import pages.sections.transportUnit.{TransportUnitSection, TransportUnitTypePage}
 import play.api.i18n.Messages
+import play.twirl.api.HtmlFormat
 import queries.TransportUnitsCount
 import uk.gov.hmrc.govukfrontend.views.Aliases.Text
-import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.{Actions, Card, CardTitle, SummaryList}
+import uk.gov.hmrc.govukfrontend.views.viewmodels.content.HtmlContent
+import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist._
 import viewmodels.checkAnswers.sections.transportUnit._
 import viewmodels.govuk.summarylist._
+import viewmodels.taskList.{Completed, InProgress, TaskListStatus}
+import views.html.components.{link, span}
 
 import javax.inject.Inject
 
-class TransportUnitsAddToListHelper @Inject()(implicit link: views.html.components.link) {
+class TransportUnitsAddToListHelper @Inject()(implicit link: link, tagHelper: TagHelper, span: span) {
 
   def allTransportUnitsSummary(onReviewPage: Boolean)(implicit request: DataRequest[_], messages: Messages): Seq[SummaryList] = {
     request.userAnswers.get(TransportUnitsCount) match {
@@ -41,25 +45,69 @@ class TransportUnitsAddToListHelper @Inject()(implicit link: views.html.componen
 
   private def summaryList(idx: Index, onReviewPage: Boolean)(implicit request: DataRequest[_], messages: Messages): SummaryList = {
     val isTransportUnitAFixedTransportInstallation = request.userAnswers.get(TransportUnitTypePage(idx)).contains(FixedTransport)
+
+    val transportUnitStatus = TransportUnitSection(idx).status
+
     SummaryListViewModel(
       rows = Seq(
-        Some(TransportUnitTypeSummary.row(idx, onReviewPage)),
+        TransportUnitTypeSummary.row(idx, onReviewPage),
         if (!isTransportUnitAFixedTransportInstallation) Some(TransportUnitIdentitySummary.row(idx, onReviewPage)) else None,
         if (!isTransportUnitAFixedTransportInstallation) Some(TransportSealChoiceSummary.row(idx, onReviewPage)) else None,
-        if (!isTransportUnitAFixedTransportInstallation) Some(TransportSealTypeSummary.row(idx, onReviewPage)) else None,
-        if (!isTransportUnitAFixedTransportInstallation) Some(TransportSealInformationSummary.row(idx, onReviewPage)) else None,
+        if (!isTransportUnitAFixedTransportInstallation) TransportSealTypeSummary.row(idx, onReviewPage) else None,
+        if (!isTransportUnitAFixedTransportInstallation) TransportSealInformationSummary.row(idx, onReviewPage) else None,
         if (!isTransportUnitAFixedTransportInstallation) Some(TransportUnitGiveMoreInformationSummary.row(idx, onReviewPage)) else None
-      ).flatMap(_.flatten)
-    ).copy(card = Some(Card(
-      title = Some(CardTitle(Text(messages("transportUnitsAddToList.transportUnitCardTitle", idx.displayIndex)))),
-      actions = Some(Actions(items = if(onReviewPage) Seq() else Seq(
-        ActionItemViewModel(
-          content = Text(messages("site.remove")),
-          href = transportUnitRoutes.TransportUnitRemoveUnitController.onPageLoad(request.userAnswers.ern, request.userAnswers.arc, idx).url,
-          id = s"removeTransportUnit${idx.displayIndex}"
-        ).withVisuallyHiddenText(messages("transportUnitsAddToList.transportUnitCardTitle", idx.displayIndex))
-      ))))
+      ).flatten
+    ).copy(card = Some(
+      Card(
+        title = Some(createCardTitle(idx, transportUnitStatus)),
+        actions = Some(
+          Actions(
+            items = if(onReviewPage) Seq() else Seq(
+              continueEditingLink(idx, transportUnitStatus),
+              Some(removeLink(idx))
+            ).flatten
+          )
+        )
+      )
     ))
+  }
+
+  private def removeLink(idx: Index)(implicit request: DataRequest[_], messages: Messages): ActionItem = {
+    ActionItemViewModel(
+      content = Text(messages("site.remove")),
+      href = transportUnitRoutes.TransportUnitRemoveUnitController.onPageLoad(request.ern, request.arc, idx).url,
+      id = s"removeTransportUnit${idx.displayIndex}"
+    ).withVisuallyHiddenText(messages("transportUnitsAddToList.transportUnitCardTitle", idx.displayIndex))
+  }
+
+  private def continueEditingLink(idx: Index, transportUnitStatus: TaskListStatus)
+                                 (implicit request: DataRequest[_], messages: Messages): Option[ActionItem] = {
+    if (transportUnitStatus == InProgress) {
+      Some(
+        ActionItemViewModel(
+          content = Text(messages("site.continueEditing")),
+          href = transportUnitRoutes.TransportUnitTypeController.onPageLoad(request.ern, request.arc, idx, NormalMode).url,
+          id = s"editTransportUnit${idx.displayIndex}"
+        ).withVisuallyHiddenText(messages("transportUnitsAddToList.transportUnitCardTitle", idx.displayIndex))
+      )
+    } else {
+      None
+    }
+  }
+
+  private def createCardTitle(idx: Index, transportUnitStatus: TaskListStatus)(implicit messages: Messages): CardTitle = {
+    if (transportUnitStatus == Completed) {
+      CardTitle(Text(messages("transportUnitsAddToList.transportUnitCardTitle", idx.displayIndex)))
+    } else {
+      CardTitle(
+        HtmlContent(HtmlFormat.fill(
+          Seq(
+            span(messages("transportUnitsAddToList.transportUnitCardTitle", idx.displayIndex), Some("govuk-!-margin-right-2")),
+            tagHelper.incompleteTag()
+          )
+        ))
+      )
+    }
   }
 
 }

--- a/app/viewmodels/helpers/TransportUnitsAddToListHelper.scala
+++ b/app/viewmodels/helpers/TransportUnitsAddToListHelper.scala
@@ -47,15 +47,16 @@ class TransportUnitsAddToListHelper @Inject()(implicit link: link, tagHelper: Ta
     val isTransportUnitAFixedTransportInstallation = request.userAnswers.get(TransportUnitTypePage(idx)).contains(FixedTransport)
 
     val transportUnitStatus = TransportUnitSection(idx).status
+    val hideChangeLinks = onReviewPage || transportUnitStatus != Completed
 
     SummaryListViewModel(
       rows = Seq(
-        TransportUnitTypeSummary.row(idx, onReviewPage),
-        if (!isTransportUnitAFixedTransportInstallation) Some(TransportUnitIdentitySummary.row(idx, onReviewPage)) else None,
-        if (!isTransportUnitAFixedTransportInstallation) Some(TransportSealChoiceSummary.row(idx, onReviewPage)) else None,
-        if (!isTransportUnitAFixedTransportInstallation) TransportSealTypeSummary.row(idx, onReviewPage) else None,
-        if (!isTransportUnitAFixedTransportInstallation) TransportSealInformationSummary.row(idx, onReviewPage) else None,
-        if (!isTransportUnitAFixedTransportInstallation) Some(TransportUnitGiveMoreInformationSummary.row(idx, onReviewPage)) else None
+        TransportUnitTypeSummary.row(idx, hideChangeLinks),
+        if (!isTransportUnitAFixedTransportInstallation) Some(TransportUnitIdentitySummary.row(idx, hideChangeLinks)) else None,
+        if (!isTransportUnitAFixedTransportInstallation) Some(TransportSealChoiceSummary.row(idx, hideChangeLinks)) else None,
+        if (!isTransportUnitAFixedTransportInstallation) TransportSealTypeSummary.row(idx, hideChangeLinks) else None,
+        if (!isTransportUnitAFixedTransportInstallation) TransportSealInformationSummary.row(idx, hideChangeLinks) else None,
+        if (!isTransportUnitAFixedTransportInstallation) Some(TransportUnitGiveMoreInformationSummary.row(idx, hideChangeLinks)) else None
       ).flatten
     ).copy(card = Some(
       Card(

--- a/app/viewmodels/taskList/TaskList.scala
+++ b/app/viewmodels/taskList/TaskList.scala
@@ -47,6 +47,11 @@ case object CannotStartYet extends TaskListStatus {
   override val tagClass = Some("govuk-tag--grey")
 }
 
+case object UpdateNeeded extends TaskListStatus {
+  override val msgKey: String = "taskListStatus.updateNeeded"
+  override val tagClass = Some("govuk-tag--orange")
+}
+
 case class TaskListSectionRow(taskName: String,
                               id: String,
                               link: Option[String],

--- a/conf/messages
+++ b/conf/messages
@@ -47,6 +47,7 @@ taskListStatus.notStarted = Not Started
 taskListStatus.cannotStartYet = Cannot Start Yet
 taskListStatus.incomplete = Incomplete
 taskListStatus.review = Review
+taskListStatus.updateNeeded = Update Needed
 
 unitOfMeasure.kilograms.short = kg
 unitOfMeasure.kilograms.long = kilograms

--- a/conf/messages
+++ b/conf/messages
@@ -756,7 +756,8 @@ transportUnitsAddToList.transportUnitCardTitle = Transport unit {0}
 transportUnitsAddToList.legend = Do you need to add another transport unit?
 transportUnitsAddToList.1 = Yes
 transportUnitsAddToList.2 = I will add more transport units later
-transportUnitsAddToList.3 = No, this is the only transport unit for this movement
+transportUnitsAddToList.3.singular = No, this is the only transport unit for this movement
+transportUnitsAddToList.3.plural = No, these are all the transport units
 transportUnitsAddToList.error.required = Select yes if you need to add another transport unit
 
 transportUnitRemoveUnit.title = Are you sure you want to remove transport unit {0}?

--- a/test-utils/fixtures/messages/BaseMessages.scala
+++ b/test-utils/fixtures/messages/BaseMessages.scala
@@ -59,7 +59,10 @@ trait BaseMessages { _: i18n =>
   val remove: String = "Remove"
   val continueEditing: String = "Continue editing"
   val sectionNotComplete: String => String = section => s"$section section not complete"
-  val incomplete: String = "Incomplete"
+  val incompleteTag: String = "Incomplete"
+  val updateNeededTag: String = "Update Needed"
+  val errorMessageHelper: String => String = s"Error: " + _
+  val incompleteMessageHelper: String => String = _ + " " + incompleteTag
 }
 
 trait BaseEnglish extends BaseMessages with EN

--- a/test-utils/fixtures/messages/sections/destination/DestinationConsigneeDetailsMessages.scala
+++ b/test-utils/fixtures/messages/sections/destination/DestinationConsigneeDetailsMessages.scala
@@ -28,8 +28,6 @@ object DestinationConsigneeDetailsMessages {
     val cyaLabel: String = "Use consignee details"
 
     val cyaChangeHidden: String = "use consignee details"
-
-    val errorMessageHelper: String => String = s"Error: " + _
   }
 
   object English extends ViewMessages with BaseEnglish

--- a/test-utils/fixtures/messages/sections/transportUnit/TransportUnitAddToListMessages.scala
+++ b/test-utils/fixtures/messages/sections/transportUnit/TransportUnitAddToListMessages.scala
@@ -29,11 +29,11 @@ object TransportUnitAddToListMessages {
 
     val question = "Do you need to add another transport unit?"
     val yesOption = "Yes"
-    val noOption = "No, this is the only transport unit for this movement"
+    val noOptionSingular = "No, this is the only transport unit for this movement"
+    val noOptionPlural = "No, these are all the transport units"
     val optionDivider = "or"
     val laterOption = "I will add more transport units later"
     val errorMessage = "Select yes if you need to add another transport unit"
-    val errorMessageHelper: String => String = s"Error: " + _
 
 
     val transportUnit1 = "Transport unit 1"

--- a/test-utils/fixtures/messages/sections/transportUnit/TransportUnitIdentityMessages.scala
+++ b/test-utils/fixtures/messages/sections/transportUnit/TransportUnitIdentityMessages.scala
@@ -54,8 +54,6 @@ object TransportUnitIdentityMessages {
     val cyaLabel: String = "Transport identifier"
 
     val cyaChangeHidden: String = "transport identifier"
-
-    val errorMessageHelper: String => String = s"Error: " + _
   }
 
   object English extends ViewMessages with BaseEnglish

--- a/test/pages/sections/transportUnit/TransportSealTypePageSpec.scala
+++ b/test/pages/sections/transportUnit/TransportSealTypePageSpec.scala
@@ -17,41 +17,13 @@
 package pages.sections.transportUnit
 
 import base.SpecBase
-import models.Index
-import models.response.emcsTfe.TransportDetailsModel
-import models.sections.transportUnit.TransportSealTypeModel
-import play.api.libs.json.Json
 import play.api.test.FakeRequest
 
 class TransportSealTypePageSpec extends SpecBase {
 
-  val transportDetails: TransportDetailsModel = maxGetMovementResponse.transportDetails.head
-
   "getValueFromIE801" - {
-    "must return Some(_)" - {
-      "when the index is valid" in {
-        TransportSealTypePage(testIndex1).getValueFromIE801(dataRequest(FakeRequest(), emptyUserAnswers.set(
-          TransportUnitsSectionUnits, Json.arr(Json.obj())
-        ))) mustBe Some(TransportSealTypeModel(transportDetails.commercialSealIdentification.get, transportDetails.sealInformation))
-      }
-    }
-
-    "must return None" - {
-
-      //scalastyle:off
-      "when the index exceeds the transport units in 801" in {
-        TransportSealTypePage(Index(3)).getValueFromIE801(dataRequest(FakeRequest(), emptyUserAnswers.set(
-          TransportUnitsSectionUnits, Json.arr(Json.obj(), Json.obj(), Json.obj(), Json.obj())
-        ))) mustBe None
-      }
-
-      "when there are no transport units" in {
-        TransportSealTypePage(testIndex1).getValueFromIE801(dataRequest(
-          FakeRequest(),
-          movementDetails = maxGetMovementResponse.copy(transportDetails = Seq.empty)
-        )) mustBe None
-      }
+    "must return None" in {
+      TransportSealTypePage(testIndex1).getValueFromIE801(dataRequest(FakeRequest())) mustBe None
     }
   }
-
 }

--- a/test/pages/sections/transportUnit/TransportUnitGiveMoreInformationPageSpec.scala
+++ b/test/pages/sections/transportUnit/TransportUnitGiveMoreInformationPageSpec.scala
@@ -17,40 +17,13 @@
 package pages.sections.transportUnit
 
 import base.SpecBase
-import models.Index
-import models.response.emcsTfe.TransportDetailsModel
-import play.api.libs.json.Json
 import play.api.test.FakeRequest
 
 class TransportUnitGiveMoreInformationPageSpec extends SpecBase {
 
-  val transportDetails: TransportDetailsModel = maxGetMovementResponse.transportDetails.head
-
   "getValueFromIE801" - {
-    "must return Some(_)" - {
-      "when the index is valid" in {
-        TransportUnitGiveMoreInformationPage(testIndex1).getValueFromIE801(dataRequest(FakeRequest(), emptyUserAnswers.set(
-          TransportUnitsSectionUnits, Json.arr(Json.obj())
-        ))) mustBe Some(transportDetails.complementaryInformation)
-      }
-    }
-
-    "must return None" - {
-
-      //scalastyle:off
-      "when the index exceeds the transport units in 801" in {
-        TransportUnitGiveMoreInformationPage(Index(3)).getValueFromIE801(dataRequest(FakeRequest(), emptyUserAnswers.set(
-          TransportUnitsSectionUnits, Json.arr(Json.obj(), Json.obj(), Json.obj(), Json.obj())
-        ))) mustBe None
-      }
-
-      "when there are no transport units" in {
-        TransportUnitGiveMoreInformationPage(testIndex1).getValueFromIE801(dataRequest(
-          FakeRequest(),
-          movementDetails = maxGetMovementResponse.copy(transportDetails = Seq.empty)
-        )) mustBe None
-      }
+    "must return None" in {
+      TransportUnitGiveMoreInformationPage(testIndex1).getValueFromIE801(dataRequest(FakeRequest())) mustBe None
     }
   }
-
 }

--- a/test/pages/sections/transportUnit/TransportUnitIdentityPageSpec.scala
+++ b/test/pages/sections/transportUnit/TransportUnitIdentityPageSpec.scala
@@ -17,40 +17,13 @@
 package pages.sections.transportUnit
 
 import base.SpecBase
-import models.Index
-import models.response.emcsTfe.TransportDetailsModel
-import play.api.libs.json.Json
 import play.api.test.FakeRequest
 
 class TransportUnitIdentityPageSpec extends SpecBase {
 
-  val transportDetails: TransportDetailsModel = maxGetMovementResponse.transportDetails.head
-
   "getValueFromIE801" - {
-    "must return Some(_)" - {
-      "when the index is valid" in {
-        TransportUnitIdentityPage(testIndex1).getValueFromIE801(dataRequest(FakeRequest(), emptyUserAnswers.set(
-          TransportUnitsSectionUnits, Json.arr(Json.obj())
-        ))) mustBe transportDetails.identityOfTransportUnits
-      }
-    }
-
-    "must return None" - {
-
-      //scalastyle:off
-      "when the index exceeds the transport units in 801" in {
-        TransportUnitIdentityPage(Index(3)).getValueFromIE801(dataRequest(FakeRequest(), emptyUserAnswers.set(
-          TransportUnitsSectionUnits, Json.arr(Json.obj(), Json.obj(), Json.obj(), Json.obj())
-        ))) mustBe None
-      }
-
-      "when there are no transport units" in {
-        TransportUnitIdentityPage(testIndex1).getValueFromIE801(dataRequest(
-          FakeRequest(),
-          movementDetails = maxGetMovementResponse.copy(transportDetails = Seq.empty)
-        )) mustBe None
-      }
+    "must return None" in {
+      TransportUnitIdentityPage(testIndex1).getValueFromIE801(dataRequest(FakeRequest())) mustBe None
     }
   }
-
 }

--- a/test/pages/sections/transportUnit/TransportUnitTypePageSpec.scala
+++ b/test/pages/sections/transportUnit/TransportUnitTypePageSpec.scala
@@ -17,10 +17,7 @@
 package pages.sections.transportUnit
 
 import base.SpecBase
-import models.Index
 import models.response.emcsTfe.TransportDetailsModel
-import models.sections.transportUnit.TransportUnitType.Container
-import play.api.libs.json.Json
 import play.api.test.FakeRequest
 
 class TransportUnitTypePageSpec extends SpecBase {
@@ -28,36 +25,8 @@ class TransportUnitTypePageSpec extends SpecBase {
   val transportDetails: TransportDetailsModel = maxGetMovementResponse.transportDetails.head
 
   "getValueFromIE801" - {
-    "must return Some(_)" - {
-      "when the index is valid" in {
-        TransportUnitTypePage(testIndex1).getValueFromIE801(dataRequest(FakeRequest(), emptyUserAnswers.set(
-          TransportUnitsSectionUnits, Json.arr(Json.obj())),
-          movementDetails = maxGetMovementResponse.copy(transportDetails = Seq(transportDetails.copy(transportUnitCode = "1"))))) mustBe Some(Container)
-      }
-    }
-
-    "must return None" - {
-
-      "when the code is invalid" in {
-        TransportUnitTypePage(testIndex1).getValueFromIE801(dataRequest(FakeRequest(), emptyUserAnswers.set(
-          TransportUnitsSectionUnits, Json.arr(Json.obj())
-        ))) mustBe None
-      }
-
-      //scalastyle:off
-      "when the index exceeds the transport units in 801" in {
-        TransportUnitTypePage(Index(3)).getValueFromIE801(dataRequest(FakeRequest(), emptyUserAnswers.set(
-          TransportUnitsSectionUnits, Json.arr(Json.obj(), Json.obj(), Json.obj(), Json.obj())
-        ))) mustBe None
-      }
-
-      "when there are no transport units" in {
-        TransportUnitTypePage(testIndex1).getValueFromIE801(dataRequest(
-          FakeRequest(),
-          movementDetails = maxGetMovementResponse.copy(transportDetails = Seq.empty)
-        )) mustBe None
-      }
+    "must return None" in {
+      TransportUnitTypePage(testIndex1).getValueFromIE801(dataRequest(FakeRequest())) mustBe None
     }
   }
-
 }

--- a/test/viewmodels/checkAnswers/sections/transportUnit/TransportSealChoiceSummarySpec.scala
+++ b/test/viewmodels/checkAnswers/sections/transportUnit/TransportSealChoiceSummarySpec.scala
@@ -47,17 +47,15 @@ class TransportSealChoiceSummarySpec extends SpecBase with Matchers with Transpo
             implicit lazy val request = dataRequest(FakeRequest(), emptyUserAnswers)
 
             TransportSealChoiceSummary.row(testIndex1, onReviewPage = false) mustBe
-              Some(
-                SummaryListRowViewModel(
-                  key = messagesForLanguage.cyaLabel,
-                  value = Value(Text(messagesForLanguage.notProvided)),
-                  actions = Seq(
-                    ActionItemViewModel(
-                      content = messagesForLanguage.change,
-                      href = transportUnitRoutes.TransportSealChoiceController.onPageLoad(testErn, testArc, testIndex1, CheckMode).url,
-                      id = "changeTransportSealChoice1"
-                    ).withVisuallyHiddenText(messagesForLanguage.moreInfoCyaChangeHidden)
-                  )
+              SummaryListRowViewModel(
+                key = messagesForLanguage.cyaLabel,
+                value = Value(Text(messagesForLanguage.notProvided)),
+                actions = Seq(
+                  ActionItemViewModel(
+                    content = messagesForLanguage.change,
+                    href = transportUnitRoutes.TransportSealChoiceController.onPageLoad(testErn, testArc, testIndex1, CheckMode).url,
+                    id = "changeTransportSealChoice1"
+                  ).withVisuallyHiddenText(messagesForLanguage.moreInfoCyaChangeHidden)
                 )
               )
           }
@@ -67,12 +65,10 @@ class TransportSealChoiceSummarySpec extends SpecBase with Matchers with Transpo
             implicit lazy val request = dataRequest(FakeRequest(), emptyUserAnswers)
 
             TransportSealChoiceSummary.row(testIndex1, onReviewPage = true) mustBe
-              Some(
-                SummaryListRowViewModel(
-                  key = messagesForLanguage.cyaLabel,
-                  value = Value(Text(messagesForLanguage.notProvided)),
-                  actions = Seq()
-                )
+              SummaryListRowViewModel(
+                key = messagesForLanguage.cyaLabel,
+                value = Value(Text(messagesForLanguage.notProvided)),
+                actions = Seq()
               )
           }
         }
@@ -84,17 +80,15 @@ class TransportSealChoiceSummarySpec extends SpecBase with Matchers with Transpo
             implicit lazy val request = dataRequest(FakeRequest(), emptyUserAnswers.set(TransportSealChoicePage(testIndex1), true))
 
             TransportSealChoiceSummary.row(testIndex1, onReviewPage = false) mustBe
-              Some(
-                SummaryListRowViewModel(
-                  key = messagesForLanguage.cyaLabel,
-                  value = Value(Text("Yes")),
-                  actions = Seq(
-                    ActionItemViewModel(
-                      content = messagesForLanguage.change,
-                      href = transportUnitRoutes.TransportSealChoiceController.onPageLoad(testErn, testArc, testIndex1, CheckMode).url,
-                      id = "changeTransportSealChoice1"
-                    ).withVisuallyHiddenText(messagesForLanguage.moreInfoCyaChangeHidden)
-                  )
+              SummaryListRowViewModel(
+                key = messagesForLanguage.cyaLabel,
+                value = Value(Text("Yes")),
+                actions = Seq(
+                  ActionItemViewModel(
+                    content = messagesForLanguage.change,
+                    href = transportUnitRoutes.TransportSealChoiceController.onPageLoad(testErn, testArc, testIndex1, CheckMode).url,
+                    id = "changeTransportSealChoice1"
+                  ).withVisuallyHiddenText(messagesForLanguage.moreInfoCyaChangeHidden)
                 )
               )
           }
@@ -104,12 +98,10 @@ class TransportSealChoiceSummarySpec extends SpecBase with Matchers with Transpo
             implicit lazy val request = dataRequest(FakeRequest(), emptyUserAnswers.set(TransportSealChoicePage(testIndex1), true))
 
             TransportSealChoiceSummary.row(testIndex1, onReviewPage = true) mustBe
-              Some(
-                SummaryListRowViewModel(
-                  key = messagesForLanguage.cyaLabel,
-                  value = Value(Text("Yes")),
-                  actions = Seq()
-                )
+              SummaryListRowViewModel(
+                key = messagesForLanguage.cyaLabel,
+                value = Value(Text("Yes")),
+                actions = Seq()
               )
           }
         }

--- a/test/viewmodels/checkAnswers/sections/transportUnit/TransportSealChoiceSummarySpec.scala
+++ b/test/viewmodels/checkAnswers/sections/transportUnit/TransportSealChoiceSummarySpec.scala
@@ -46,7 +46,7 @@ class TransportSealChoiceSummarySpec extends SpecBase with Matchers with Transpo
 
             implicit lazy val request = dataRequest(FakeRequest(), emptyUserAnswers)
 
-            TransportSealChoiceSummary.row(testIndex1, onReviewPage = false) mustBe
+            TransportSealChoiceSummary.row(testIndex1, hideChangeLinks = false) mustBe
               SummaryListRowViewModel(
                 key = messagesForLanguage.cyaLabel,
                 value = Value(Text(messagesForLanguage.notProvided)),
@@ -64,7 +64,7 @@ class TransportSealChoiceSummarySpec extends SpecBase with Matchers with Transpo
 
             implicit lazy val request = dataRequest(FakeRequest(), emptyUserAnswers)
 
-            TransportSealChoiceSummary.row(testIndex1, onReviewPage = true) mustBe
+            TransportSealChoiceSummary.row(testIndex1, hideChangeLinks = true) mustBe
               SummaryListRowViewModel(
                 key = messagesForLanguage.cyaLabel,
                 value = Value(Text(messagesForLanguage.notProvided)),
@@ -79,7 +79,7 @@ class TransportSealChoiceSummarySpec extends SpecBase with Matchers with Transpo
 
             implicit lazy val request = dataRequest(FakeRequest(), emptyUserAnswers.set(TransportSealChoicePage(testIndex1), true))
 
-            TransportSealChoiceSummary.row(testIndex1, onReviewPage = false) mustBe
+            TransportSealChoiceSummary.row(testIndex1, hideChangeLinks = false) mustBe
               SummaryListRowViewModel(
                 key = messagesForLanguage.cyaLabel,
                 value = Value(Text("Yes")),
@@ -97,7 +97,7 @@ class TransportSealChoiceSummarySpec extends SpecBase with Matchers with Transpo
 
             implicit lazy val request = dataRequest(FakeRequest(), emptyUserAnswers.set(TransportSealChoicePage(testIndex1), true))
 
-            TransportSealChoiceSummary.row(testIndex1, onReviewPage = true) mustBe
+            TransportSealChoiceSummary.row(testIndex1, hideChangeLinks = true) mustBe
               SummaryListRowViewModel(
                 key = messagesForLanguage.cyaLabel,
                 value = Value(Text("Yes")),

--- a/test/viewmodels/checkAnswers/sections/transportUnit/TransportSealInformationSummarySpec.scala
+++ b/test/viewmodels/checkAnswers/sections/transportUnit/TransportSealInformationSummarySpec.scala
@@ -50,7 +50,7 @@ class TransportSealInformationSummarySpec extends SpecBase with Matchers with Tr
 
             implicit lazy val request: DataRequest[AnyContentAsEmpty.type] = dataRequest(FakeRequest(), emptyUserAnswers)
 
-            TransportSealInformationSummary.row(testIndex1, onReviewPage = false) mustBe None
+            TransportSealInformationSummary.row(testIndex1, hideChangeLinks = false) mustBe None
           }
         }
 
@@ -62,7 +62,7 @@ class TransportSealInformationSummarySpec extends SpecBase with Matchers with Tr
               .set(TransportSealChoicePage(testIndex1), false)
             )
 
-            TransportSealInformationSummary.row(testIndex1, onReviewPage = false) mustBe None
+            TransportSealInformationSummary.row(testIndex1, hideChangeLinks = false) mustBe None
           }
 
           "must output no rows if TransportSealChoicePage is not present" in {
@@ -70,7 +70,7 @@ class TransportSealInformationSummarySpec extends SpecBase with Matchers with Tr
               .set(TransportSealTypePage(testIndex1), transportSealTypeModelMax)
             )
 
-            TransportSealInformationSummary.row(testIndex1, onReviewPage = false) mustBe None
+            TransportSealInformationSummary.row(testIndex1, hideChangeLinks = false) mustBe None
           }
 
           "must output the expected row for TransportSealInformation if TransportSealChoicePage is true" in {
@@ -80,7 +80,7 @@ class TransportSealInformationSummarySpec extends SpecBase with Matchers with Tr
               .set(TransportSealChoicePage(testIndex1), true)
             )
 
-            TransportSealInformationSummary.row(testIndex1, onReviewPage = false) mustBe
+            TransportSealInformationSummary.row(testIndex1, hideChangeLinks = false) mustBe
               Some(
                 SummaryListRowViewModel(
                   key = messagesForLanguage.moreInfoCYA,
@@ -104,7 +104,7 @@ class TransportSealInformationSummarySpec extends SpecBase with Matchers with Tr
               .set(TransportSealChoicePage(testIndex1), true)
             )
 
-            TransportSealInformationSummary.row(testIndex1, onReviewPage = true) mustBe
+            TransportSealInformationSummary.row(testIndex1, hideChangeLinks = true) mustBe
               Some(
                 SummaryListRowViewModel(
                   key = messagesForLanguage.moreInfoCYA,
@@ -122,7 +122,7 @@ class TransportSealInformationSummarySpec extends SpecBase with Matchers with Tr
               .set(TransportSealChoicePage(testIndex1), false)
             )
 
-            TransportSealInformationSummary.row(testIndex1, onReviewPage = false) mustBe None
+            TransportSealInformationSummary.row(testIndex1, hideChangeLinks = false) mustBe None
           }
 
           "must output no rows if TransportSealChoicePage is not present" in {
@@ -130,7 +130,7 @@ class TransportSealInformationSummarySpec extends SpecBase with Matchers with Tr
               .set(TransportSealTypePage(testIndex1), transportSealTypeModelMin)
             )
 
-            TransportSealInformationSummary.row(testIndex1, onReviewPage = false) mustBe None
+            TransportSealInformationSummary.row(testIndex1, hideChangeLinks = false) mustBe None
           }
 
           "must output a row with a link to add more information and TransportSealChoicePage is true" in {
@@ -140,7 +140,7 @@ class TransportSealInformationSummarySpec extends SpecBase with Matchers with Tr
               .set(TransportSealChoicePage(testIndex1), true)
             )
 
-            TransportSealInformationSummary.row(testIndex1, onReviewPage = false) mustBe
+            TransportSealInformationSummary.row(testIndex1, hideChangeLinks = false) mustBe
               Some(
                 SummaryListRowViewModel(
                   key = messagesForLanguage.moreInfoCYA,
@@ -159,7 +159,7 @@ class TransportSealInformationSummarySpec extends SpecBase with Matchers with Tr
               .set(TransportSealChoicePage(testIndex1), true)
             )
 
-            TransportSealInformationSummary.row(testIndex1, onReviewPage = true) mustBe
+            TransportSealInformationSummary.row(testIndex1, hideChangeLinks = true) mustBe
               Some(
                 SummaryListRowViewModel(
                   key = messagesForLanguage.moreInfoCYA,

--- a/test/viewmodels/checkAnswers/sections/transportUnit/TransportSealTypeSummarySpec.scala
+++ b/test/viewmodels/checkAnswers/sections/transportUnit/TransportSealTypeSummarySpec.scala
@@ -142,28 +142,6 @@ class TransportSealTypeSummarySpec extends SpecBase with Matchers with Transport
               )
           }
 
-          "must output row with answer if TransportSealChoicePage is true (value from 801)" in {
-
-            implicit lazy val request = dataRequest(FakeRequest(), emptyUserAnswers
-              .set(TransportSealChoicePage(testIndex1), true)
-            )
-
-            TransportSealTypeSummary.row(testIndex1, onReviewPage = false) mustBe
-              Some(
-                SummaryListRowViewModel(
-                  key = messagesForLanguage.sealTypeCYA,
-                  value = Value(Text("TransportDetailsCommercialSealIdentification1")),
-                  actions = Seq(
-                    ActionItemViewModel(
-                      content = messagesForLanguage.change,
-                      href = controllers.sections.transportUnit.routes.TransportSealTypeController.onPageLoad(testErn, testArc, testIndex1, CheckMode).url,
-                      id = "changeTransportSealType1"
-                    ).withVisuallyHiddenText(messagesForLanguage.sealTypeCyaChangeHidden)
-                  )
-                )
-              )
-          }
-
           "must output the expected row with no change link - when on review page" in {
 
             implicit lazy val request = dataRequest(FakeRequest(), emptyUserAnswers

--- a/test/viewmodels/checkAnswers/sections/transportUnit/TransportSealTypeSummarySpec.scala
+++ b/test/viewmodels/checkAnswers/sections/transportUnit/TransportSealTypeSummarySpec.scala
@@ -46,7 +46,7 @@ class TransportSealTypeSummarySpec extends SpecBase with Matchers with Transport
 
             implicit lazy val request = dataRequest(FakeRequest(), emptyUserAnswers)
 
-            TransportSealTypeSummary.row(testIndex1, onReviewPage = false) mustBe None
+            TransportSealTypeSummary.row(testIndex1, hideChangeLinks = false) mustBe None
           }
 
           "must output no row if TransportSealChoicePage is false" in {
@@ -55,7 +55,7 @@ class TransportSealTypeSummarySpec extends SpecBase with Matchers with Transport
               .set(TransportSealChoicePage(testIndex1), false)
             )
 
-            TransportSealTypeSummary.row(testIndex1, onReviewPage = false) mustBe None
+            TransportSealTypeSummary.row(testIndex1, hideChangeLinks = false) mustBe None
           }
 
           "must output a not provided row if TransportSealChoicePage is true and TransportSealTypePage is not answered " +
@@ -66,7 +66,7 @@ class TransportSealTypeSummarySpec extends SpecBase with Matchers with Transport
               movementDetails = maxGetMovementResponse.copy(transportDetails = Seq(TransportDetailsModel("unitcode", None, None, None, None)))
             )
 
-            TransportSealTypeSummary.row(testIndex1, onReviewPage = false) mustBe Some(
+            TransportSealTypeSummary.row(testIndex1, hideChangeLinks = false) mustBe Some(
               SummaryListRowViewModel(
                 key = messagesForLanguage.sealTypeCYA,
                 value = Value(Text(messagesForLanguage.notProvided)),
@@ -88,7 +88,7 @@ class TransportSealTypeSummarySpec extends SpecBase with Matchers with Transport
               movementDetails = maxGetMovementResponse.copy(transportDetails = Seq(TransportDetailsModel("unitcode", None, None, None, None)))
             )
 
-            TransportSealTypeSummary.row(testIndex1, onReviewPage = true) mustBe Some(
+            TransportSealTypeSummary.row(testIndex1, hideChangeLinks = true) mustBe Some(
               SummaryListRowViewModel(
                 key = messagesForLanguage.sealTypeCYA,
                 value = Value(Text(messagesForLanguage.notProvided)),
@@ -107,7 +107,7 @@ class TransportSealTypeSummarySpec extends SpecBase with Matchers with Transport
               .set(TransportSealChoicePage(testIndex1), false)
             )
 
-            TransportSealTypeSummary.row(testIndex1, onReviewPage = false) mustBe None
+            TransportSealTypeSummary.row(testIndex1, hideChangeLinks = false) mustBe None
           }
 
           "must output no row if TransportSealChoicePage is not answered" in {
@@ -116,7 +116,7 @@ class TransportSealTypeSummarySpec extends SpecBase with Matchers with Transport
               .set(TransportSealTypePage(testIndex1), transportSealTypeModelMax)
             )
 
-            TransportSealTypeSummary.row(testIndex1, onReviewPage = false) mustBe None
+            TransportSealTypeSummary.row(testIndex1, hideChangeLinks = false) mustBe None
           }
 
           "must output the expected row for TransportSealType and TransportSealChoicePage is true" in {
@@ -126,7 +126,7 @@ class TransportSealTypeSummarySpec extends SpecBase with Matchers with Transport
               .set(TransportSealChoicePage(testIndex1), true)
             )
 
-            TransportSealTypeSummary.row(testIndex1, onReviewPage = false) mustBe
+            TransportSealTypeSummary.row(testIndex1, hideChangeLinks = false) mustBe
               Some(
                 SummaryListRowViewModel(
                   key = messagesForLanguage.sealTypeCYA,
@@ -149,7 +149,7 @@ class TransportSealTypeSummarySpec extends SpecBase with Matchers with Transport
               .set(TransportSealChoicePage(testIndex1), true)
             )
 
-            TransportSealTypeSummary.row(testIndex1, onReviewPage = true) mustBe
+            TransportSealTypeSummary.row(testIndex1, hideChangeLinks = true) mustBe
               Some(
                 SummaryListRowViewModel(
                   key = messagesForLanguage.sealTypeCYA,

--- a/test/viewmodels/checkAnswers/sections/transportUnit/TransportUnitGiveMoreInformationSummarySpec.scala
+++ b/test/viewmodels/checkAnswers/sections/transportUnit/TransportUnitGiveMoreInformationSummarySpec.scala
@@ -43,7 +43,7 @@ class TransportUnitGiveMoreInformationSummarySpec extends SpecBase with Matchers
           "must output the expected row - when not on review page" in {
             implicit lazy val request = dataRequest(FakeRequest(), emptyUserAnswers, movementDetails = maxGetMovementResponse.copy(transportDetails = Seq.empty))
 
-            TransportUnitGiveMoreInformationSummary.row(testIndex1, onReviewPage = false) mustBe Some(
+            TransportUnitGiveMoreInformationSummary.row(testIndex1, onReviewPage = false) mustBe
               SummaryListRowViewModel(
                 key = messagesForLanguage.cyaLabel,
                 value = Value(
@@ -53,19 +53,17 @@ class TransportUnitGiveMoreInformationSummarySpec extends SpecBase with Matchers
                 ),
                 actions = Seq()
               )
-            )
           }
 
           "must output the expected row - when on review page" in {
             implicit lazy val request = dataRequest(FakeRequest(), emptyUserAnswers, movementDetails = maxGetMovementResponse.copy(transportDetails = Seq.empty))
 
-            TransportUnitGiveMoreInformationSummary.row(testIndex1, onReviewPage = true) mustBe Some(
+            TransportUnitGiveMoreInformationSummary.row(testIndex1, onReviewPage = true) mustBe
               SummaryListRowViewModel(
                 key = messagesForLanguage.cyaLabel,
                 value = Value(Text(messagesForLanguage.notProvided)),
                 actions = Seq()
               )
-            )
           }
         }
 
@@ -74,7 +72,7 @@ class TransportUnitGiveMoreInformationSummarySpec extends SpecBase with Matchers
           "must output the expected row - with a change link when not on review page" in {
             implicit lazy val request = dataRequest(FakeRequest(), emptyUserAnswers.set(TransportUnitGiveMoreInformationPage(testIndex1), Some("value")))
 
-            TransportUnitGiveMoreInformationSummary.row(testIndex1, onReviewPage = false) mustBe Some(
+            TransportUnitGiveMoreInformationSummary.row(testIndex1, onReviewPage = false) mustBe
               SummaryListRowViewModel(
                 key = messagesForLanguage.cyaLabel,
                 value = Value(Text("value")),
@@ -86,19 +84,17 @@ class TransportUnitGiveMoreInformationSummarySpec extends SpecBase with Matchers
                   ).withVisuallyHiddenText(messagesForLanguage.cyaChangeHidden)
                 )
               )
-            )
           }
 
           "must output the expected row - with no change link when on review page" in {
             implicit lazy val request = dataRequest(FakeRequest(), emptyUserAnswers.set(TransportUnitGiveMoreInformationPage(testIndex1), Some("value")))
 
-            TransportUnitGiveMoreInformationSummary.row(testIndex1, onReviewPage = true) mustBe Some(
+            TransportUnitGiveMoreInformationSummary.row(testIndex1, onReviewPage = true) mustBe
               SummaryListRowViewModel(
                 key = messagesForLanguage.cyaLabel,
                 value = Value(Text("value")),
                 actions = Seq()
               )
-            )
           }
         }
       }

--- a/test/viewmodels/checkAnswers/sections/transportUnit/TransportUnitGiveMoreInformationSummarySpec.scala
+++ b/test/viewmodels/checkAnswers/sections/transportUnit/TransportUnitGiveMoreInformationSummarySpec.scala
@@ -43,7 +43,7 @@ class TransportUnitGiveMoreInformationSummarySpec extends SpecBase with Matchers
           "must output the expected row - when not on review page" in {
             implicit lazy val request = dataRequest(FakeRequest(), emptyUserAnswers, movementDetails = maxGetMovementResponse.copy(transportDetails = Seq.empty))
 
-            TransportUnitGiveMoreInformationSummary.row(testIndex1, onReviewPage = false) mustBe
+            TransportUnitGiveMoreInformationSummary.row(testIndex1, hideChangeLinks = false) mustBe
               SummaryListRowViewModel(
                 key = messagesForLanguage.cyaLabel,
                 value = Value(
@@ -58,7 +58,7 @@ class TransportUnitGiveMoreInformationSummarySpec extends SpecBase with Matchers
           "must output the expected row - when on review page" in {
             implicit lazy val request = dataRequest(FakeRequest(), emptyUserAnswers, movementDetails = maxGetMovementResponse.copy(transportDetails = Seq.empty))
 
-            TransportUnitGiveMoreInformationSummary.row(testIndex1, onReviewPage = true) mustBe
+            TransportUnitGiveMoreInformationSummary.row(testIndex1, hideChangeLinks = true) mustBe
               SummaryListRowViewModel(
                 key = messagesForLanguage.cyaLabel,
                 value = Value(Text(messagesForLanguage.notProvided)),
@@ -72,7 +72,7 @@ class TransportUnitGiveMoreInformationSummarySpec extends SpecBase with Matchers
           "must output the expected row - with a change link when not on review page" in {
             implicit lazy val request = dataRequest(FakeRequest(), emptyUserAnswers.set(TransportUnitGiveMoreInformationPage(testIndex1), Some("value")))
 
-            TransportUnitGiveMoreInformationSummary.row(testIndex1, onReviewPage = false) mustBe
+            TransportUnitGiveMoreInformationSummary.row(testIndex1, hideChangeLinks = false) mustBe
               SummaryListRowViewModel(
                 key = messagesForLanguage.cyaLabel,
                 value = Value(Text("value")),
@@ -89,7 +89,7 @@ class TransportUnitGiveMoreInformationSummarySpec extends SpecBase with Matchers
           "must output the expected row - with no change link when on review page" in {
             implicit lazy val request = dataRequest(FakeRequest(), emptyUserAnswers.set(TransportUnitGiveMoreInformationPage(testIndex1), Some("value")))
 
-            TransportUnitGiveMoreInformationSummary.row(testIndex1, onReviewPage = true) mustBe
+            TransportUnitGiveMoreInformationSummary.row(testIndex1, hideChangeLinks = true) mustBe
               SummaryListRowViewModel(
                 key = messagesForLanguage.cyaLabel,
                 value = Value(Text("value")),

--- a/test/viewmodels/checkAnswers/sections/transportUnit/TransportUnitIdentitySummarySpec.scala
+++ b/test/viewmodels/checkAnswers/sections/transportUnit/TransportUnitIdentitySummarySpec.scala
@@ -45,7 +45,7 @@ class TransportUnitIdentitySummarySpec extends SpecBase with Matchers {
 
             implicit lazy val request = dataRequest(FakeRequest(), emptyUserAnswers, movementDetails = maxGetMovementResponse.copy(transportDetails = Seq.empty))
 
-            TransportUnitIdentitySummary.row(testIndex1, onReviewPage = false) mustBe
+            TransportUnitIdentitySummary.row(testIndex1, hideChangeLinks = false) mustBe
               SummaryListRowViewModel(
                 key = messagesForLanguage.cyaLabel,
                 value = Value(Text(messagesForLanguage.notProvided)),
@@ -63,7 +63,7 @@ class TransportUnitIdentitySummarySpec extends SpecBase with Matchers {
 
             implicit lazy val request = dataRequest(FakeRequest(), emptyUserAnswers, movementDetails = maxGetMovementResponse.copy(transportDetails = Seq.empty))
 
-            TransportUnitIdentitySummary.row(testIndex1, onReviewPage = true) mustBe
+            TransportUnitIdentitySummary.row(testIndex1, hideChangeLinks = true) mustBe
               SummaryListRowViewModel(
                 key = messagesForLanguage.cyaLabel,
                 value = Value(Text(messagesForLanguage.notProvided)),
@@ -78,7 +78,7 @@ class TransportUnitIdentitySummarySpec extends SpecBase with Matchers {
 
             implicit lazy val request = dataRequest(FakeRequest(), emptyUserAnswers.set(TransportUnitIdentityPage(testIndex1), "testName"))
 
-            TransportUnitIdentitySummary.row(testIndex1, onReviewPage = false) mustBe
+            TransportUnitIdentitySummary.row(testIndex1, hideChangeLinks = false) mustBe
               SummaryListRowViewModel(
                 key = messagesForLanguage.cyaLabel,
                 value = Value(Text("testName")),
@@ -96,7 +96,7 @@ class TransportUnitIdentitySummarySpec extends SpecBase with Matchers {
 
             implicit lazy val request = dataRequest(FakeRequest(), emptyUserAnswers.set(TransportUnitIdentityPage(testIndex1), "testName"))
 
-            TransportUnitIdentitySummary.row(testIndex1, onReviewPage = true) mustBe
+            TransportUnitIdentitySummary.row(testIndex1, hideChangeLinks = true) mustBe
               SummaryListRowViewModel(
                 key = messagesForLanguage.cyaLabel,
                 value = Value(Text("testName")),

--- a/test/viewmodels/checkAnswers/sections/transportUnit/TransportUnitIdentitySummarySpec.scala
+++ b/test/viewmodels/checkAnswers/sections/transportUnit/TransportUnitIdentitySummarySpec.scala
@@ -46,17 +46,15 @@ class TransportUnitIdentitySummarySpec extends SpecBase with Matchers {
             implicit lazy val request = dataRequest(FakeRequest(), emptyUserAnswers, movementDetails = maxGetMovementResponse.copy(transportDetails = Seq.empty))
 
             TransportUnitIdentitySummary.row(testIndex1, onReviewPage = false) mustBe
-              Some(
-                SummaryListRowViewModel(
-                  key = messagesForLanguage.cyaLabel,
-                  value = Value(Text(messagesForLanguage.notProvided)),
-                  actions = Seq(
-                    ActionItemViewModel(
-                      content = messagesForLanguage.change,
-                      href = transportUnitRoutes.TransportUnitIdentityController.onPageLoad(testErn, testArc, testIndex1, CheckMode).url,
-                      id = "changeTransportUnitIdentity1"
-                    ).withVisuallyHiddenText(messagesForLanguage.cyaChangeHidden)
-                  )
+              SummaryListRowViewModel(
+                key = messagesForLanguage.cyaLabel,
+                value = Value(Text(messagesForLanguage.notProvided)),
+                actions = Seq(
+                  ActionItemViewModel(
+                    content = messagesForLanguage.change,
+                    href = transportUnitRoutes.TransportUnitIdentityController.onPageLoad(testErn, testArc, testIndex1, CheckMode).url,
+                    id = "changeTransportUnitIdentity1"
+                  ).withVisuallyHiddenText(messagesForLanguage.cyaChangeHidden)
                 )
               )
           }
@@ -66,12 +64,10 @@ class TransportUnitIdentitySummarySpec extends SpecBase with Matchers {
             implicit lazy val request = dataRequest(FakeRequest(), emptyUserAnswers, movementDetails = maxGetMovementResponse.copy(transportDetails = Seq.empty))
 
             TransportUnitIdentitySummary.row(testIndex1, onReviewPage = true) mustBe
-              Some(
-                SummaryListRowViewModel(
-                  key = messagesForLanguage.cyaLabel,
-                  value = Value(Text(messagesForLanguage.notProvided)),
-                  actions = Seq()
-                )
+              SummaryListRowViewModel(
+                key = messagesForLanguage.cyaLabel,
+                value = Value(Text(messagesForLanguage.notProvided)),
+                actions = Seq()
               )
           }
         }
@@ -83,17 +79,15 @@ class TransportUnitIdentitySummarySpec extends SpecBase with Matchers {
             implicit lazy val request = dataRequest(FakeRequest(), emptyUserAnswers.set(TransportUnitIdentityPage(testIndex1), "testName"))
 
             TransportUnitIdentitySummary.row(testIndex1, onReviewPage = false) mustBe
-              Some(
-                SummaryListRowViewModel(
-                  key = messagesForLanguage.cyaLabel,
-                  value = Value(Text("testName")),
-                  actions = Seq(
-                    ActionItemViewModel(
-                      content = messagesForLanguage.change,
-                      href = transportUnitRoutes.TransportUnitIdentityController.onPageLoad(testErn, testArc, testIndex1, CheckMode).url,
-                      id = "changeTransportUnitIdentity1"
-                    ).withVisuallyHiddenText(messagesForLanguage.cyaChangeHidden)
-                  )
+              SummaryListRowViewModel(
+                key = messagesForLanguage.cyaLabel,
+                value = Value(Text("testName")),
+                actions = Seq(
+                  ActionItemViewModel(
+                    content = messagesForLanguage.change,
+                    href = transportUnitRoutes.TransportUnitIdentityController.onPageLoad(testErn, testArc, testIndex1, CheckMode).url,
+                    id = "changeTransportUnitIdentity1"
+                  ).withVisuallyHiddenText(messagesForLanguage.cyaChangeHidden)
                 )
               )
           }
@@ -103,12 +97,10 @@ class TransportUnitIdentitySummarySpec extends SpecBase with Matchers {
             implicit lazy val request = dataRequest(FakeRequest(), emptyUserAnswers.set(TransportUnitIdentityPage(testIndex1), "testName"))
 
             TransportUnitIdentitySummary.row(testIndex1, onReviewPage = true) mustBe
-              Some(
-                SummaryListRowViewModel(
-                  key = messagesForLanguage.cyaLabel,
-                  value = Value(Text("testName")),
-                  actions = Seq()
-                )
+              SummaryListRowViewModel(
+                key = messagesForLanguage.cyaLabel,
+                value = Value(Text("testName")),
+                actions = Seq()
               )
           }
         }

--- a/test/viewmodels/checkAnswers/sections/transportUnit/TransportUnitTypeSummarySpec.scala
+++ b/test/viewmodels/checkAnswers/sections/transportUnit/TransportUnitTypeSummarySpec.scala
@@ -76,7 +76,7 @@ class TransportUnitTypeSummarySpec extends SpecBase with Matchers {
 
               implicit lazy val request = dataRequest(FakeRequest(), emptyUserAnswers)
 
-              TransportUnitTypeSummary.row(testIndex1, onReviewPage = false) mustBe None
+              TransportUnitTypeSummary.row(testIndex1, hideChangeLinks = false) mustBe None
             }
           }
 
@@ -94,7 +94,7 @@ class TransportUnitTypeSummarySpec extends SpecBase with Matchers {
 
                   implicit lazy val request = dataRequest(FakeRequest(), emptyUserAnswers.set(TransportUnitTypePage(testIndex1), transportUnitType))
 
-                  TransportUnitTypeSummary.row(testIndex1, onReviewPage = false) mustBe
+                  TransportUnitTypeSummary.row(testIndex1, hideChangeLinks = false) mustBe
                     Some(
                       SummaryListRowViewModel(
                         key = messagesForLanguage.addToListLabel,
@@ -114,7 +114,7 @@ class TransportUnitTypeSummarySpec extends SpecBase with Matchers {
 
                   implicit lazy val request = dataRequest(FakeRequest(), emptyUserAnswers.set(TransportUnitTypePage(testIndex1), transportUnitType))
 
-                  TransportUnitTypeSummary.row(testIndex1, onReviewPage = true) mustBe
+                  TransportUnitTypeSummary.row(testIndex1, hideChangeLinks = true) mustBe
                     Some(
                       SummaryListRowViewModel(
                         key = messagesForLanguage.addToListLabel,

--- a/test/viewmodels/helpers/TagHelperSpec.scala
+++ b/test/viewmodels/helpers/TagHelperSpec.scala
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package viewmodels.helpers
+
+import base.SpecBase
+import fixtures.messages.TaskListStatusMessages
+import play.api.i18n.Messages
+import play.api.test.FakeRequest
+
+class TagHelperSpec extends SpecBase {
+
+  implicit lazy val msgs: Messages = messages(FakeRequest())
+
+  lazy val tagHelper = app.injector.instanceOf[TagHelper]
+  lazy val tag = app.injector.instanceOf[views.html.components.tag]
+
+  Seq(TaskListStatusMessages.English).foreach { messagesForLang =>
+
+    s"when being called for message language code of '${messagesForLang.lang.code}'" - {
+
+      ".updateNeededTag" - {
+
+        "should render an UpdateNeededTag with correct data" in {
+
+          val result = tagHelper.updateNeededTag()
+
+          result mustBe tag(
+            message = messagesForLang.updateNeededTag,
+            colour = "orange",
+            extraClasses = "float-none govuk-!-margin-left-1"
+          )
+        }
+      }
+
+      ".incompleteTag" - {
+
+        "should render an UpdateNeededTag with correct data" in {
+
+          val result = tagHelper.incompleteTag()
+
+          result mustBe tag(
+            message = messagesForLang.incompleteTag,
+            colour = "red"
+          )
+        }
+      }
+    }
+  }
+}

--- a/test/viewmodels/helpers/TransportUnitsAddToListHelperSpec.scala
+++ b/test/viewmodels/helpers/TransportUnitsAddToListHelperSpec.scala
@@ -188,10 +188,10 @@ class TransportUnitsAddToListHelperSpec extends SpecBase {
                     )
                   ))))),
                 rows = Seq(
-                  TransportUnitTypeSummary.row(testIndex1, onReviewPage = false).get,
-                  TransportUnitIdentitySummary.row(testIndex1, onReviewPage = false),
-                  TransportSealChoiceSummary.row(testIndex1, onReviewPage = false),
-                  TransportUnitGiveMoreInformationSummary.row(testIndex1, onReviewPage = false)
+                  TransportUnitTypeSummary.row(testIndex1, hideChangeLinks = true).get,
+                  TransportUnitIdentitySummary.row(testIndex1, hideChangeLinks = true),
+                  TransportSealChoiceSummary.row(testIndex1, hideChangeLinks = true),
+                  TransportUnitGiveMoreInformationSummary.row(testIndex1, hideChangeLinks = true)
                 )
               )
             )

--- a/test/viewmodels/helpers/TransportUnitsAddToListHelperSpec.scala
+++ b/test/viewmodels/helpers/TransportUnitsAddToListHelperSpec.scala
@@ -19,7 +19,7 @@ package viewmodels.helpers
 import base.SpecBase
 import controllers.sections.transportUnit.{routes => transportUnitRoutes}
 import fixtures.messages.sections.transportUnit.TransportUnitAddToListMessages
-import models.UserAnswers
+import models.{NormalMode, UserAnswers}
 import models.requests.DataRequest
 import models.sections.transportUnit.TransportSealTypeModel
 import models.sections.transportUnit.TransportUnitType.{FixedTransport, Tractor}
@@ -27,49 +27,159 @@ import pages.sections.transportUnit._
 import play.api.i18n.Messages
 import play.api.mvc.AnyContentAsEmpty
 import play.api.test.FakeRequest
-import uk.gov.hmrc.govukfrontend.views.viewmodels.content.Text
+import play.twirl.api.HtmlFormat
+import uk.gov.hmrc.govukfrontend.views.viewmodels.content.{HtmlContent, Text}
 import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist._
 import viewmodels.checkAnswers.sections.transportUnit._
-import views.html.components.link
+import views.html.components.{link, span}
 
 class TransportUnitsAddToListHelperSpec extends SpecBase {
 
-  class Setup(userAnswers: UserAnswers = emptyUserAnswers) {
-    implicit lazy val link: link = app.injector.instanceOf[link]
-    implicit lazy val request: DataRequest[AnyContentAsEmpty.type] = dataRequest(FakeRequest(), userAnswers)
+  implicit lazy val link: link = app.injector.instanceOf[link]
+  lazy val helper: TransportUnitsAddToListHelper = app.injector.instanceOf[TransportUnitsAddToListHelper]
+  lazy val tagHelper: TagHelper = app.injector.instanceOf[TagHelper]
+  lazy val span: span = app.injector.instanceOf[span]
 
-    lazy val helper: TransportUnitsAddToListHelper = app.injector.instanceOf[TransportUnitsAddToListHelper]
+  class Setup(userAnswers: UserAnswers = emptyUserAnswers) {
+    implicit lazy val request: DataRequest[AnyContentAsEmpty.type] = dataRequest(FakeRequest(), userAnswers)
   }
 
   "TransportUnitsAddToListHelper" - {
     Seq(TransportUnitAddToListMessages.English).foreach { msg =>
-      Seq(true, false).foreach { onReviewPage =>
-        "return nothing" - {
-          s"when no answers specified for '${msg.lang.code}' - when onReview page = $onReviewPage" in new Setup() {
-            implicit val msgs: Messages = messages(Seq(msg.lang))
-            override implicit lazy val request: DataRequest[AnyContentAsEmpty.type] =
-              dataRequest(FakeRequest(), emptyUserAnswers, movementDetails = maxGetMovementResponse.copy(transportDetails = Seq.empty))
-            helper.allTransportUnitsSummary(onReviewPage) mustBe Nil
+
+      s"when rendered in language code of ${msg.lang.code}" - {
+
+        Seq(true, false).foreach { onReviewPage =>
+
+          s"when onReview page = $onReviewPage" - {
+
+            "return nothing" - {
+              s"when no answers specified" in new Setup() {
+                implicit val msgs: Messages = messages(Seq(msg.lang))
+                override implicit lazy val request: DataRequest[AnyContentAsEmpty.type] =
+                  dataRequest(FakeRequest(), emptyUserAnswers, movementDetails = maxGetMovementResponse.copy(transportDetails = Seq.empty))
+                helper.allTransportUnitsSummary(onReviewPage) mustBe Nil
+              }
+            }
+
+            s"return required rows" - {
+
+              "when all answers entered and single transport units" in new Setup(
+                emptyUserAnswers
+                  .set(TransportUnitTypePage(testIndex1), Tractor)
+                  .set(TransportUnitIdentityPage(testIndex1), "wee")
+                  .set(TransportSealChoicePage(testIndex1), true)
+                  .set(TransportSealTypePage(testIndex1), TransportSealTypeModel("seal Type", Some("more seal info")))
+                  .set(TransportUnitGiveMoreInformationChoicePage(testIndex1), true)
+                  .set(TransportUnitGiveMoreInformationPage(testIndex1), Some("more information for transport unit"))) {
+                implicit lazy val msgs: Messages = messages(Seq(msg.lang))
+
+                helper.allTransportUnitsSummary(onReviewPage) mustBe Seq(
+                  SummaryList(
+                    card = Some(Card(
+                      title = Some(CardTitle(Text(msg.transportUnit1))),
+                      actions = Some(Actions(items = if (onReviewPage) Seq() else Seq(
+                        ActionItem(
+                          href = transportUnitRoutes.TransportUnitRemoveUnitController.onPageLoad(testErn, testArc, testIndex1).url,
+                          content = Text(msg.remove),
+                          visuallyHiddenText = Some(msg.transportUnit1),
+                          attributes = Map("id" -> "removeTransportUnit1")
+                        )
+                      ))))),
+                    rows = Seq(
+                      TransportUnitTypeSummary.row(testIndex1, onReviewPage).get,
+                      TransportUnitIdentitySummary.row(testIndex1, onReviewPage),
+                      TransportSealChoiceSummary.row(testIndex1, onReviewPage),
+                      TransportSealTypeSummary.row(testIndex1, onReviewPage).get,
+                      TransportSealInformationSummary.row(testIndex1, onReviewPage).get,
+                      TransportUnitGiveMoreInformationSummary.row(testIndex1, onReviewPage)
+                    )
+                  )
+                )
+              }
+
+              "when all answers entered and multiple transport units" in new Setup(emptyUserAnswers
+                .set(TransportUnitTypePage(testIndex1), Tractor)
+                .set(TransportUnitIdentityPage(testIndex1), "wee")
+                .set(TransportSealChoicePage(testIndex1), true)
+                .set(TransportSealTypePage(testIndex1), TransportSealTypeModel("seal Type", Some("more seal info")))
+                .set(TransportUnitGiveMoreInformationChoicePage(testIndex1), true)
+                .set(TransportUnitGiveMoreInformationPage(testIndex1), Some("more information for transport unit"))
+                .set(TransportUnitTypePage(testIndex2), FixedTransport)
+                .set(TransportUnitIdentityPage(testIndex2), "wee2")
+                .set(TransportSealChoicePage(testIndex2), true)
+                .set(TransportSealTypePage(testIndex2), TransportSealTypeModel("seal Type", Some("more seal info 2")))
+                .set(TransportUnitGiveMoreInformationChoicePage(testIndex2), true)
+                .set(TransportUnitGiveMoreInformationPage(testIndex2), Some("more information for transport unit 2"))) {
+                implicit lazy val msgs: Messages = messages(Seq(msg.lang))
+
+                helper.allTransportUnitsSummary(onReviewPage) mustBe Seq(
+                  SummaryList(
+                    card = Some(Card(
+                      title = Some(CardTitle(Text(msg.transportUnit1))),
+                      actions = Some(Actions(items = if (onReviewPage) Seq() else Seq(
+                        ActionItem(
+                          href = transportUnitRoutes.TransportUnitRemoveUnitController.onPageLoad(testErn, testArc, testIndex1).url,
+                          content = Text(msg.remove),
+                          visuallyHiddenText = Some(msg.transportUnit1),
+                          attributes = Map("id" -> "removeTransportUnit1")
+                        )
+                      ))))),
+                    rows = Seq(
+                      TransportUnitTypeSummary.row(testIndex1, onReviewPage).get,
+                      TransportUnitIdentitySummary.row(testIndex1, onReviewPage),
+                      TransportSealChoiceSummary.row(testIndex1, onReviewPage),
+                      TransportSealTypeSummary.row(testIndex1, onReviewPage).get,
+                      TransportSealInformationSummary.row(testIndex1, onReviewPage).get,
+                      TransportUnitGiveMoreInformationSummary.row(testIndex1, onReviewPage)
+                    )
+                  ),
+                  SummaryList(
+                    card = Some(Card(
+                      title = Some(CardTitle(Text(msg.transportUnit2))),
+                      actions = Some(Actions(items = if (onReviewPage) Seq() else Seq(
+                        ActionItem(
+                          href = transportUnitRoutes.TransportUnitRemoveUnitController.onPageLoad(testErn, testArc, testIndex2).url,
+                          content = Text(msg.remove),
+                          visuallyHiddenText = Some(msg.transportUnit2),
+                          attributes = Map("id" -> "removeTransportUnit2")
+                        )
+                      ))))),
+                    rows = Seq(
+                      TransportUnitTypeSummary.row(testIndex2, onReviewPage).get
+                    )
+                  )
+                )
+              }
+            }
           }
         }
 
-        s"return required rows when all answers filled out - when onReviewPage = $onReviewPage" - {
+        s"return an incomplete card with tag and continue link" - {
 
-          s"when all answers entered '${msg.lang.code}' and single transport units" in new Setup(
-            emptyUserAnswers
-              .set(TransportUnitTypePage(testIndex1), Tractor)
-              .set(TransportUnitIdentityPage(testIndex1), "wee")
-              .set(TransportSealChoicePage(testIndex1), true)
-              .set(TransportSealTypePage(testIndex1), TransportSealTypeModel("seal Type", Some("more seal info")))
-              .set(TransportUnitGiveMoreInformationChoicePage(testIndex1), true)
-              .set(TransportUnitGiveMoreInformationPage(testIndex1), Some("more information for transport unit"))) {
+          s"when NOT all answers entered" in new Setup(
+            emptyUserAnswers.set(TransportUnitTypePage(testIndex1), Tractor)
+          ) {
             implicit lazy val msgs: Messages = messages(Seq(msg.lang))
 
-            helper.allTransportUnitsSummary(onReviewPage) mustBe Seq(
+            helper.allTransportUnitsSummary(onReviewPage = false) mustBe Seq(
               SummaryList(
                 card = Some(Card(
-                  title = Some(CardTitle(Text(msg.transportUnit1))),
-                  actions = Some(Actions(items = if(onReviewPage) Seq() else Seq(
+                  title = Some(CardTitle(
+                    HtmlContent(HtmlFormat.fill(
+                      Seq(
+                        span(msg.transportUnit1, Some("govuk-!-margin-right-2")),
+                        tagHelper.incompleteTag()
+                      )
+                    ))
+                  )),
+                  actions = Some(Actions(items = Seq(
+                    ActionItem(
+                      href = transportUnitRoutes.TransportUnitTypeController.onPageLoad(testErn, testArc, testIndex1, NormalMode).url,
+                      content = Text(msg.continueEditing),
+                      visuallyHiddenText = Some(msg.transportUnit1),
+                      attributes = Map("id" -> "editTransportUnit1")
+                    ),
                     ActionItem(
                       href = transportUnitRoutes.TransportUnitRemoveUnitController.onPageLoad(testErn, testArc, testIndex1).url,
                       content = Text(msg.remove),
@@ -78,66 +188,10 @@ class TransportUnitsAddToListHelperSpec extends SpecBase {
                     )
                   ))))),
                 rows = Seq(
-                  TransportUnitTypeSummary.row(testIndex1, onReviewPage).get,
-                  TransportUnitIdentitySummary.row(testIndex1, onReviewPage).get,
-                  TransportSealChoiceSummary.row(testIndex1, onReviewPage).get,
-                  TransportSealTypeSummary.row(testIndex1, onReviewPage).get,
-                  TransportSealInformationSummary.row(testIndex1, onReviewPage).get,
-                  TransportUnitGiveMoreInformationSummary.row(testIndex1, onReviewPage).get
-                )
-              )
-            )
-          }
-
-          s"when all answers entered '${msg.lang.code}' and multiple transport units" in new Setup(emptyUserAnswers
-            .set(TransportUnitTypePage(testIndex1), Tractor)
-            .set(TransportUnitIdentityPage(testIndex1), "wee")
-            .set(TransportSealChoicePage(testIndex1), true)
-            .set(TransportSealTypePage(testIndex1), TransportSealTypeModel("seal Type", Some("more seal info")))
-            .set(TransportUnitGiveMoreInformationChoicePage(testIndex1), true)
-            .set(TransportUnitGiveMoreInformationPage(testIndex1), Some("more information for transport unit"))
-            .set(TransportUnitTypePage(testIndex2), FixedTransport)
-            .set(TransportUnitIdentityPage(testIndex2), "wee2")
-            .set(TransportSealChoicePage(testIndex2), true)
-            .set(TransportSealTypePage(testIndex2), TransportSealTypeModel("seal Type", Some("more seal info 2")))
-            .set(TransportUnitGiveMoreInformationChoicePage(testIndex2), true)
-            .set(TransportUnitGiveMoreInformationPage(testIndex2), Some("more information for transport unit 2"))) {
-            implicit lazy val msgs: Messages = messages(Seq(msg.lang))
-
-            helper.allTransportUnitsSummary(onReviewPage) mustBe Seq(
-              SummaryList(
-                card = Some(Card(
-                  title = Some(CardTitle(Text(msg.transportUnit1))),
-                  actions = Some(Actions(items = if(onReviewPage) Seq() else Seq(
-                    ActionItem(
-                      href = transportUnitRoutes.TransportUnitRemoveUnitController.onPageLoad(testErn, testArc, testIndex1).url,
-                      content = Text(msg.remove),
-                      visuallyHiddenText = Some(msg.transportUnit1),
-                      attributes = Map("id" -> "removeTransportUnit1")
-                    )
-                  ))))),
-                rows = Seq(
-                  TransportUnitTypeSummary.row(testIndex1, onReviewPage).get,
-                  TransportUnitIdentitySummary.row(testIndex1, onReviewPage).get,
-                  TransportSealChoiceSummary.row(testIndex1, onReviewPage).get,
-                  TransportSealTypeSummary.row(testIndex1, onReviewPage).get,
-                  TransportSealInformationSummary.row(testIndex1, onReviewPage).get,
-                  TransportUnitGiveMoreInformationSummary.row(testIndex1, onReviewPage).get
-                )
-              ),
-              SummaryList(
-                card = Some(Card(
-                  title = Some(CardTitle(Text(msg.transportUnit2))),
-                  actions = Some(Actions(items = if(onReviewPage) Seq() else Seq(
-                    ActionItem(
-                      href = transportUnitRoutes.TransportUnitRemoveUnitController.onPageLoad(testErn, testArc, testIndex2).url,
-                      content = Text(msg.remove),
-                      visuallyHiddenText = Some(msg.transportUnit2),
-                      attributes = Map("id" -> "removeTransportUnit2")
-                    )
-                  ))))),
-                rows = Seq(
-                  TransportUnitTypeSummary.row(testIndex2, onReviewPage).get
+                  TransportUnitTypeSummary.row(testIndex1, onReviewPage = false).get,
+                  TransportUnitIdentitySummary.row(testIndex1, onReviewPage = false),
+                  TransportSealChoiceSummary.row(testIndex1, onReviewPage = false),
+                  TransportUnitGiveMoreInformationSummary.row(testIndex1, onReviewPage = false)
                 )
               )
             )
@@ -146,5 +200,4 @@ class TransportUnitsAddToListHelperSpec extends SpecBase {
       }
     }
   }
-
 }

--- a/test/views/sections/transportUnit/TransportUnitAddToListViewSpec.scala
+++ b/test/views/sections/transportUnit/TransportUnitAddToListViewSpec.scala
@@ -52,165 +52,196 @@ class TransportUnitAddToListViewSpec extends SpecBase with ViewBehaviours {
 
     Seq(TransportUnitAddToListMessages.English).foreach { messagesForLanguage =>
 
-      s"when being rendered in lang code of '${messagesForLanguage.lang.code}' for singular item" - {
+      s"when being rendered in lang code of '${messagesForLanguage.lang.code}'" - {
 
-        implicit val msgs: Messages = messages(Seq(messagesForLanguage.lang))
+        s"for singular item" - {
 
-        val userAnswers = emptyUserAnswers
-          .set(TransportUnitTypePage(testIndex1), Tractor)
-          .set(TransportUnitIdentityPage(testIndex1), "wee")
-          .set(TransportSealChoicePage(testIndex1), true)
-          .set(TransportSealTypePage(testIndex1), TransportSealTypeModel("seal Type", Some("more seal info")))
-          .set(TransportUnitGiveMoreInformationChoicePage(testIndex1), true)
-          .set(TransportUnitGiveMoreInformationPage(testIndex1), Some("more information for transport unit"))
+          implicit val msgs: Messages = messages(Seq(messagesForLanguage.lang))
 
-        implicit val request: DataRequest[AnyContentAsEmpty.type] = dataRequest(FakeRequest(), userAnswers)
+          val userAnswers = emptyUserAnswers
+            .set(TransportUnitTypePage(testIndex1), Tractor)
+            .set(TransportUnitIdentityPage(testIndex1), "wee")
+            .set(TransportSealChoicePage(testIndex1), true)
+            .set(TransportSealTypePage(testIndex1), TransportSealTypeModel("seal Type", Some("more seal info")))
+            .set(TransportUnitGiveMoreInformationChoicePage(testIndex1), true)
+            .set(TransportUnitGiveMoreInformationPage(testIndex1), Some("more information for transport unit"))
 
-        implicit val doc: Document = Jsoup.parse(
-          view(
-            optionalForm = Some(form),
-            transportUnits =  helper.allTransportUnitsSummary(onReviewPage = false),
-            mode = NormalMode
-          ).toString())
+          implicit val request: DataRequest[AnyContentAsEmpty.type] = dataRequest(FakeRequest(), userAnswers)
 
-        behave like pageWithExpectedElementsAndMessages(Seq(
-          Selectors.title -> messagesForLanguage.title,
-          Selectors.h1 -> messagesForLanguage.heading,
-          Selectors.removeItemLink(1) -> messagesForLanguage.removeLink1WithHiddenText,
-          Selectors.cardTitle -> messagesForLanguage.transportUnit1,
-          Selectors.legendQuestion -> messagesForLanguage.question,
-          Selectors.radioButton(1) -> messagesForLanguage.yesOption,
-          Selectors.radioButton(2) -> messagesForLanguage.noOption,
-          Selectors.radioButton(4) -> messagesForLanguage.laterOption,
-          Selectors.button -> messagesForLanguage.saveAndContinue,
-          Selectors.returnToDraftLink -> messagesForLanguage.returnToDraft
-        ))
-      }
+          implicit val doc: Document = Jsoup.parse(
+            view(
+              optionalForm = Some(form),
+              transportUnits = helper.allTransportUnitsSummary(onReviewPage = false),
+              mode = NormalMode
+            ).toString())
 
-      s"when being rendered in lang code of '${messagesForLanguage.lang.code}' for singular item with error" - {
+          behave like pageWithExpectedElementsAndMessages(Seq(
+            Selectors.title -> messagesForLanguage.title,
+            Selectors.h1 -> messagesForLanguage.heading,
+            Selectors.removeItemLink(1) -> messagesForLanguage.removeLink1WithHiddenText,
+            Selectors.cardTitle -> messagesForLanguage.transportUnit1,
+            Selectors.legendQuestion -> messagesForLanguage.question,
+            Selectors.radioButton(1) -> messagesForLanguage.yesOption,
+            Selectors.radioButton(2) -> messagesForLanguage.noOptionSingular,
+            Selectors.radioButton(4) -> messagesForLanguage.laterOption,
+            Selectors.button -> messagesForLanguage.saveAndContinue,
+            Selectors.returnToDraftLink -> messagesForLanguage.returnToDraft
+          ))
+        }
 
-        implicit val msgs: Messages = messages(Seq(messagesForLanguage.lang))
+        s"for singular item with error" - {
 
-        val userAnswers = emptyUserAnswers
-          .set(TransportUnitTypePage(testIndex1), Tractor)
-          .set(TransportUnitIdentityPage(testIndex1), "wee")
-          .set(TransportSealChoicePage(testIndex1), true)
-          .set(TransportSealTypePage(testIndex1), TransportSealTypeModel("seal Type", Some("more seal info")))
-          .set(TransportUnitGiveMoreInformationChoicePage(testIndex1), true)
-          .set(TransportUnitGiveMoreInformationPage(testIndex1), Some("more information for transport unit"))
+          implicit val msgs: Messages = messages(Seq(messagesForLanguage.lang))
 
-        implicit val request: DataRequest[AnyContentAsEmpty.type] = dataRequest(FakeRequest(), userAnswers)
+          val userAnswers = emptyUserAnswers
+            .set(TransportUnitTypePage(testIndex1), Tractor)
+            .set(TransportUnitIdentityPage(testIndex1), "wee")
+            .set(TransportSealChoicePage(testIndex1), true)
+            .set(TransportSealTypePage(testIndex1), TransportSealTypeModel("seal Type", Some("more seal info")))
+            .set(TransportUnitGiveMoreInformationChoicePage(testIndex1), true)
+            .set(TransportUnitGiveMoreInformationPage(testIndex1), Some("more information for transport unit"))
 
-        implicit val doc: Document = Jsoup.parse(
-          view(
-            optionalForm = Some(form.bind(Map("value" -> ""))),
-            transportUnits = helper.allTransportUnitsSummary(onReviewPage = false),
-            mode = NormalMode
-          ).toString())
+          implicit val request: DataRequest[AnyContentAsEmpty.type] = dataRequest(FakeRequest(), userAnswers)
 
-        behave like pageWithExpectedElementsAndMessages(Seq(
-          Selectors.title -> messagesForLanguage.errorMessageHelper(messagesForLanguage.title),
-          Selectors.h1 -> messagesForLanguage.heading,
-          Selectors.removeItemLink(1) -> messagesForLanguage.removeLink1WithHiddenText,
-          Selectors.cardTitle -> messagesForLanguage.transportUnit1,
-          Selectors.legendQuestion -> messagesForLanguage.question,
-          Selectors.errorSummary(1) -> messagesForLanguage.errorMessage,
-          Selectors.errorField -> messagesForLanguage.errorMessageHelper(messagesForLanguage.errorMessage),
-          Selectors.radioButton(1) -> messagesForLanguage.yesOption,
-          Selectors.radioButton(2) -> messagesForLanguage.noOption,
-          Selectors.radioButton(4) -> messagesForLanguage.laterOption,
-          Selectors.button -> messagesForLanguage.saveAndContinue,
-          Selectors.returnToDraftLink -> messagesForLanguage.returnToDraft
-        ))
-      }
+          implicit val doc: Document = Jsoup.parse(
+            view(
+              optionalForm = Some(form.bind(Map("value" -> ""))),
+              transportUnits = helper.allTransportUnitsSummary(onReviewPage = false),
+              mode = NormalMode
+            ).toString())
 
-      s"when being rendered in lang code of '${messagesForLanguage.lang.code}' for multiple items" - {
+          behave like pageWithExpectedElementsAndMessages(Seq(
+            Selectors.title -> messagesForLanguage.errorMessageHelper(messagesForLanguage.title),
+            Selectors.h1 -> messagesForLanguage.heading,
+            Selectors.removeItemLink(1) -> messagesForLanguage.removeLink1WithHiddenText,
+            Selectors.cardTitle -> messagesForLanguage.transportUnit1,
+            Selectors.legendQuestion -> messagesForLanguage.question,
+            Selectors.errorSummary(1) -> messagesForLanguage.errorMessage,
+            Selectors.errorField -> messagesForLanguage.errorMessageHelper(messagesForLanguage.errorMessage),
+            Selectors.radioButton(1) -> messagesForLanguage.yesOption,
+            Selectors.radioButton(2) -> messagesForLanguage.noOptionSingular,
+            Selectors.radioButton(4) -> messagesForLanguage.laterOption,
+            Selectors.button -> messagesForLanguage.saveAndContinue,
+            Selectors.returnToDraftLink -> messagesForLanguage.returnToDraft
+          ))
+        }
 
-        implicit val msgs: Messages = messages(Seq(messagesForLanguage.lang))
+        s"for multiple items" - {
 
-        val userAnswers = emptyUserAnswers
-          .set(TransportUnitTypePage(testIndex1), Tractor)
-          .set(TransportUnitIdentityPage(testIndex1), "wee")
-          .set(TransportSealChoicePage(testIndex1), true)
-          .set(TransportSealTypePage(testIndex1), TransportSealTypeModel("seal Type", Some("more seal info")))
-          .set(TransportUnitGiveMoreInformationChoicePage(testIndex1), true)
-          .set(TransportUnitGiveMoreInformationPage(testIndex1), Some("more information for transport unit"))
-          .set(TransportUnitTypePage(testIndex2), FixedTransport)
-          .set(TransportUnitIdentityPage(testIndex2), "wee2")
-          .set(TransportSealChoicePage(testIndex2), true)
-          .set(TransportSealTypePage(testIndex2), TransportSealTypeModel("seal Type", Some("more seal info 2")))
-          .set(TransportUnitGiveMoreInformationChoicePage(testIndex2), true)
-          .set(TransportUnitGiveMoreInformationPage(testIndex2), Some("more information for transport unit 2"))
+          implicit val msgs: Messages = messages(Seq(messagesForLanguage.lang))
 
-        implicit val request: DataRequest[AnyContentAsEmpty.type] = dataRequest(FakeRequest(), userAnswers)
+          val userAnswers = emptyUserAnswers
+            .set(TransportUnitTypePage(testIndex1), Tractor)
+            .set(TransportUnitIdentityPage(testIndex1), "wee")
+            .set(TransportSealChoicePage(testIndex1), true)
+            .set(TransportSealTypePage(testIndex1), TransportSealTypeModel("seal Type", Some("more seal info")))
+            .set(TransportUnitGiveMoreInformationChoicePage(testIndex1), true)
+            .set(TransportUnitGiveMoreInformationPage(testIndex1), Some("more information for transport unit"))
+            .set(TransportUnitTypePage(testIndex2), FixedTransport)
+            .set(TransportUnitIdentityPage(testIndex2), "wee2")
+            .set(TransportSealChoicePage(testIndex2), true)
+            .set(TransportSealTypePage(testIndex2), TransportSealTypeModel("seal Type", Some("more seal info 2")))
+            .set(TransportUnitGiveMoreInformationChoicePage(testIndex2), true)
+            .set(TransportUnitGiveMoreInformationPage(testIndex2), Some("more information for transport unit 2"))
+
+          implicit val request: DataRequest[AnyContentAsEmpty.type] = dataRequest(FakeRequest(), userAnswers)
 
 
-        implicit val doc: Document = Jsoup.parse(
-          view(
-            optionalForm = Some(form),
-            transportUnits = helper.allTransportUnitsSummary(onReviewPage = false),
-            mode = NormalMode
-          ).toString())
+          implicit val doc: Document = Jsoup.parse(
+            view(
+              optionalForm = Some(form),
+              transportUnits = helper.allTransportUnitsSummary(onReviewPage = false),
+              mode = NormalMode
+            ).toString())
 
-        behave like pageWithExpectedElementsAndMessages(Seq(
-          Selectors.title -> messagesForLanguage.titleMultiple,
-          Selectors.h1 -> messagesForLanguage.headingMultiple,
-          Selectors.removeItemLink(1) -> messagesForLanguage.removeLink1WithHiddenText,
-          Selectors.removeItemLink(2) -> messagesForLanguage.removeLink2WithHiddenText,
-          Selectors.cardTitle -> messagesForLanguage.transportUnit1,
-          Selectors.legendQuestion -> messagesForLanguage.question,
-          Selectors.radioButton(1) -> messagesForLanguage.yesOption,
-          Selectors.radioButton(2) -> messagesForLanguage.noOption,
-          Selectors.radioButton(4) -> messagesForLanguage.laterOption,
-          Selectors.button -> messagesForLanguage.saveAndContinue,
-          Selectors.returnToDraftLink -> messagesForLanguage.returnToDraft
-        ))
-      }
+          behave like pageWithExpectedElementsAndMessages(Seq(
+            Selectors.title -> messagesForLanguage.titleMultiple,
+            Selectors.h1 -> messagesForLanguage.headingMultiple,
+            Selectors.removeItemLink(1) -> messagesForLanguage.removeLink1WithHiddenText,
+            Selectors.removeItemLink(2) -> messagesForLanguage.removeLink2WithHiddenText,
+            Selectors.cardTitle -> messagesForLanguage.transportUnit1,
+            Selectors.legendQuestion -> messagesForLanguage.question,
+            Selectors.radioButton(1) -> messagesForLanguage.yesOption,
+            Selectors.radioButton(2) -> messagesForLanguage.noOptionPlural,
+            Selectors.radioButton(4) -> messagesForLanguage.laterOption,
+            Selectors.button -> messagesForLanguage.saveAndContinue,
+            Selectors.returnToDraftLink -> messagesForLanguage.returnToDraft
+          ))
+        }
 
-      s"when being rendered in lang code of '${messagesForLanguage.lang.code}' for multiple items and no form" - {
+        s"for multiple items and no form" - {
 
-        implicit val msgs: Messages = messages(Seq(messagesForLanguage.lang))
+          implicit val msgs: Messages = messages(Seq(messagesForLanguage.lang))
 
-        val userAnswers = emptyUserAnswers
-          .set(TransportUnitTypePage(testIndex1), Tractor)
-          .set(TransportUnitIdentityPage(testIndex1), "wee")
-          .set(TransportSealChoicePage(testIndex1), true)
-          .set(TransportSealTypePage(testIndex1), TransportSealTypeModel("seal Type", Some("more seal info")))
-          .set(TransportUnitGiveMoreInformationChoicePage(testIndex1), true)
-          .set(TransportUnitGiveMoreInformationPage(testIndex1), Some("more information for transport unit"))
-          .set(TransportUnitTypePage(testIndex2), FixedTransport)
-          .set(TransportUnitIdentityPage(testIndex2), "wee2")
-          .set(TransportSealChoicePage(testIndex2), true)
-          .set(TransportSealTypePage(testIndex2), TransportSealTypeModel("seal Type", Some("more seal info 2")))
-          .set(TransportUnitGiveMoreInformationChoicePage(testIndex2), true)
-          .set(TransportUnitGiveMoreInformationPage(testIndex2), Some("more information for transport unit 2"))
+          val userAnswers = emptyUserAnswers
+            .set(TransportUnitTypePage(testIndex1), Tractor)
+            .set(TransportUnitIdentityPage(testIndex1), "wee")
+            .set(TransportSealChoicePage(testIndex1), true)
+            .set(TransportSealTypePage(testIndex1), TransportSealTypeModel("seal Type", Some("more seal info")))
+            .set(TransportUnitGiveMoreInformationChoicePage(testIndex1), true)
+            .set(TransportUnitGiveMoreInformationPage(testIndex1), Some("more information for transport unit"))
+            .set(TransportUnitTypePage(testIndex2), FixedTransport)
+            .set(TransportUnitIdentityPage(testIndex2), "wee2")
+            .set(TransportSealChoicePage(testIndex2), true)
+            .set(TransportSealTypePage(testIndex2), TransportSealTypeModel("seal Type", Some("more seal info 2")))
+            .set(TransportUnitGiveMoreInformationChoicePage(testIndex2), true)
+            .set(TransportUnitGiveMoreInformationPage(testIndex2), Some("more information for transport unit 2"))
 
-        implicit val request: DataRequest[AnyContentAsEmpty.type] = dataRequest(FakeRequest(), userAnswers)
+          implicit val request: DataRequest[AnyContentAsEmpty.type] = dataRequest(FakeRequest(), userAnswers)
 
-        implicit val doc: Document = Jsoup.parse(
-          view(
-            optionalForm = None,
-            transportUnits = helper.allTransportUnitsSummary(onReviewPage = false),
-            mode = NormalMode
-          ).toString())
+          implicit val doc: Document = Jsoup.parse(
+            view(
+              optionalForm = None,
+              transportUnits = helper.allTransportUnitsSummary(onReviewPage = false),
+              mode = NormalMode
+            ).toString())
 
-        behave like pageWithExpectedElementsAndMessages(Seq(
-          Selectors.title -> messagesForLanguage.titleMultiple,
-          Selectors.h1 -> messagesForLanguage.headingMultiple,
-          Selectors.removeItemLink(1) -> messagesForLanguage.removeLink1WithHiddenText,
-          Selectors.cardTitle -> messagesForLanguage.transportUnit1,
-          Selectors.button -> messagesForLanguage.saveAndContinue,
-          Selectors.returnToDraftLink -> messagesForLanguage.returnToDraft
-        ))
+          behave like pageWithExpectedElementsAndMessages(Seq(
+            Selectors.title -> messagesForLanguage.titleMultiple,
+            Selectors.h1 -> messagesForLanguage.headingMultiple,
+            Selectors.removeItemLink(1) -> messagesForLanguage.removeLink1WithHiddenText,
+            Selectors.cardTitle -> messagesForLanguage.transportUnit1,
+            Selectors.button -> messagesForLanguage.saveAndContinue,
+            Selectors.returnToDraftLink -> messagesForLanguage.returnToDraft
+          ))
 
-        behave like pageWithElementsNotPresent(
-          Seq(
-            Selectors.legendQuestion,
-            Selectors.radioButton(1),
-            Selectors.radioButton(2),
-            Selectors.radioButton(4)
+          behave like pageWithElementsNotPresent(
+            Seq(
+              Selectors.legendQuestion,
+              Selectors.radioButton(1),
+              Selectors.radioButton(2),
+              Selectors.radioButton(4)
+            )
           )
-        )
+        }
+
+        s"when an item is incomplete" - {
+
+          implicit val msgs: Messages = messages(Seq(messagesForLanguage.lang))
+
+          val userAnswers = emptyUserAnswers.set(TransportUnitTypePage(testIndex1), Tractor)
+
+          implicit val request: DataRequest[AnyContentAsEmpty.type] = dataRequest(FakeRequest(), userAnswers)
+
+          implicit val doc: Document = Jsoup.parse(
+            view(
+              optionalForm = Some(form),
+              transportUnits = helper.allTransportUnitsSummary(onReviewPage = false),
+              mode = NormalMode
+            ).toString())
+
+          behave like pageWithExpectedElementsAndMessages(Seq(
+            Selectors.title -> messagesForLanguage.title,
+            Selectors.h1 -> messagesForLanguage.heading,
+            Selectors.removeItemLink(1) -> messagesForLanguage.removeLink1WithHiddenText,
+            Selectors.cardTitle -> messagesForLanguage.incompleteMessageHelper(messagesForLanguage.transportUnit1),
+            Selectors.legendQuestion -> messagesForLanguage.question,
+            Selectors.radioButton(1) -> messagesForLanguage.yesOption,
+            Selectors.radioButton(2) -> messagesForLanguage.laterOption,
+            Selectors.button -> messagesForLanguage.saveAndContinue,
+            Selectors.returnToDraftLink -> messagesForLanguage.returnToDraft
+          ))
+        }
       }
     }
   }


### PR DESCRIPTION
Spoke to Lexi and Haresh about this, and this ticket is just to add the Incomplete tag and continue logic to TU07 (Add to List).

**Note:**
- An additional bug fix has been made to remove the retrieval of Transport Unit pages from IE801 values, because we have a separate function whcih copies the array from the IE801 and stores the TUs in UserAnswers.
- This change removes a problem where if you removed one of the existing TUs and then went to add it back in it would pre-populate with any values at the Index in the IE801 - which didn't make any sense.