### PR TITLE
[ETFE-4492] Update form validation to only output one error against a particular field at a time

### DIFF
--- a/app/forms/AddressFormProvider.scala
+++ b/app/forms/AddressFormProvider.scala
@@ -33,24 +33,36 @@ class AddressFormProvider @Inject() extends Mappings {
   def apply(): Form[UserAddress] =
     Form(mapping(
       "property" -> optional(text()
-        .verifying(maxLength(propertyMax, s"address.property.error.length"))
-        .verifying(regexp(ALPHANUMERIC_REGEX, s"address.property.error.characters"))
-        .verifying(regexpUnlessEmpty(XSS_REGEX, s"address.property.error.invalid"))),
-
+        .verifying(
+          firstError(
+            maxLength(propertyMax, s"address.property.error.length"),
+            regexp(ALPHANUMERIC_REGEX, s"address.property.error.characters"),
+            regexpUnlessEmpty(XSS_REGEX, s"address.property.error.invalid")
+          )
+        )),
       "street" -> text(s"address.street.error.required")
-        .verifying(maxLength(streetMax, s"address.street.error.length"))
-        .verifying(regexp(ALPHANUMERIC_REGEX, s"address.street.error.characters"))
-        .verifying(regexpUnlessEmpty(XSS_REGEX, s"address.street.error.invalid")),
-
+        .verifying(
+          firstError(
+            maxLength(streetMax, s"address.street.error.length"),
+            regexp(ALPHANUMERIC_REGEX, s"address.street.error.characters"),
+            regexpUnlessEmpty(XSS_REGEX, s"address.street.error.invalid")
+          )
+        ),
       "town" -> text(s"address.town.error.required")
-        .verifying(maxLength(townMax, s"address.town.error.length"))
-        .verifying(regexp(ALPHANUMERIC_REGEX, s"address.town.error.characters"))
-        .verifying(regexpUnlessEmpty(XSS_REGEX, s"address.town.error.invalid")),
-
+        .verifying(
+          firstError(
+            maxLength(townMax, s"address.town.error.length"),
+            regexp(ALPHANUMERIC_REGEX, s"address.town.error.characters"),
+            regexpUnlessEmpty(XSS_REGEX, s"address.town.error.invalid")
+          )
+        ),
       "postcode" -> text(s"address.postcode.error.required")
-        .verifying(maxLength(postcodeMax, s"address.postcode.error.length"))
-        .verifying(regexp(ALPHANUMERIC_REGEX, s"address.postcode.error.characters"))
-        .verifying(regexpUnlessEmpty(XSS_REGEX, s"address.postcode.error.invalid"))
-    )(UserAddress.apply)(UserAddress.unapply)
-  )
+        .verifying(
+          firstError(
+            maxLength(postcodeMax, s"address.postcode.error.length"),
+            regexp(ALPHANUMERIC_REGEX, s"address.postcode.error.characters"),
+            regexpUnlessEmpty(XSS_REGEX, s"address.postcode.error.invalid")
+          )
+        )
+    )(UserAddress.apply)(UserAddress.unapply))
 }

--- a/app/forms/sections/consignee/ConsigneeBusinessNameFormProvider.scala
+++ b/app/forms/sections/consignee/ConsigneeBusinessNameFormProvider.scala
@@ -27,7 +27,11 @@ class ConsigneeBusinessNameFormProvider @Inject() extends Mappings {
   def apply(): Form[String] =
     Form(
       "value" -> text("consigneeBusinessName.error.required")
-        .verifying(maxLength(182, "consigneeBusinessName.error.length"))
-        .verifying(regexpUnlessEmpty(XSS_REGEX, "consigneeBusinessName.error.invalidCharacter"))
+        .verifying(
+          firstError(
+            maxLength(182, "consigneeBusinessName.error.length"),
+            regexpUnlessEmpty(XSS_REGEX, "consigneeBusinessName.error.invalidCharacter")
+          )
+        )
     )
 }

--- a/app/forms/sections/consignee/ConsigneeExciseFormProvider.scala
+++ b/app/forms/sections/consignee/ConsigneeExciseFormProvider.scala
@@ -56,9 +56,13 @@ class ConsigneeExciseFormProvider @Inject() extends Mappings {
     Form(
       "value" -> text(noInputErrorKey)
         .transform[String](_.toUpperCase.replace(" ", ""), identity)
-        .verifying(maxLength(maxLengthValue, tooLongErrorKey))
-        .verifying(regexpUnlessEmpty(ALPHANUMERIC_REGEX, invalidCharactersErrorKey))
-        .verifying(validateErn)
+        .verifying(
+          firstError(
+            maxLength(maxLengthValue, tooLongErrorKey),
+            regexpUnlessEmpty(ALPHANUMERIC_REGEX, invalidCharactersErrorKey),
+            validateErn
+          )
+        )
     )
   }
 

--- a/app/forms/sections/consignee/ConsigneeExemptOrganisationFormProvider.scala
+++ b/app/forms/sections/consignee/ConsigneeExemptOrganisationFormProvider.scala
@@ -39,9 +39,13 @@ class ConsigneeExemptOrganisationFormProvider @Inject() extends BaseTextareaForm
             .trim,
           identity
         )
-        .verifying(maxLength(maxLength, s"consigneeExemptOrganisation.certificateSerialNumber.error.length"))
-        .verifying(regexpUnlessEmpty(ALPHANUMERIC_REGEX, s"consigneeExemptOrganisation.certificateSerialNumber.error.character"))
-        .verifying(regexpUnlessEmpty(XSS_REGEX, s"consigneeExemptOrganisation.certificateSerialNumber.error.xss"))
+        .verifying(
+          firstError(
+            maxLength(maxLength, s"consigneeExemptOrganisation.certificateSerialNumber.error.length"),
+            regexpUnlessEmpty(ALPHANUMERIC_REGEX, s"consigneeExemptOrganisation.certificateSerialNumber.error.character"),
+            regexpUnlessEmpty(XSS_REGEX, s"consigneeExemptOrganisation.certificateSerialNumber.error.xss")
+          )
+        )
     )(ExemptOrganisationDetailsModel.apply)(ExemptOrganisationDetailsModel.unapply))
 
 }

--- a/app/forms/sections/consignee/ConsigneeExportInformationFormProvider.scala
+++ b/app/forms/sections/consignee/ConsigneeExportInformationFormProvider.scala
@@ -34,7 +34,11 @@ class ConsigneeExportInformationFormProvider @Inject() extends Mappings {
           invalidKey = "consigneeExportInformation.error.invalid"
         )
       )
-        .verifying(nonEmptySet("consigneeExportInformation.error.required"))
-        .verifying(exclusiveItemInSet("consigneeExportInformation.error.exclusive", NoInformation.toString))
+        .verifying(
+          firstError(
+            nonEmptySet("consigneeExportInformation.error.required"),
+            exclusiveItemInSet("consigneeExportInformation.error.exclusive", NoInformation.toString)
+          )
+        )
     )
 }

--- a/app/forms/sections/destination/DestinationBusinessNameFormProvider.scala
+++ b/app/forms/sections/destination/DestinationBusinessNameFormProvider.scala
@@ -27,7 +27,11 @@ class DestinationBusinessNameFormProvider @Inject() extends Mappings {
   def apply(): Form[String] =
     Form(
       "value" -> text("destinationBusinessName.error.required")
-        .verifying(maxLength(182, "destinationBusinessName.error.length"))
-        .verifying(regexpUnlessEmpty(XSS_REGEX, "destinationBusinessName.error.invalid"))
+        .verifying(
+          firstError(
+            maxLength(182, "destinationBusinessName.error.length"),
+            regexpUnlessEmpty(XSS_REGEX, "destinationBusinessName.error.invalid")
+          )
+        )
     )
 }

--- a/app/forms/sections/destination/DestinationWarehouseExciseFormProvider.scala
+++ b/app/forms/sections/destination/DestinationWarehouseExciseFormProvider.scala
@@ -40,8 +40,12 @@ class DestinationWarehouseExciseFormProvider @Inject() extends Mappings {
     Form(
       "value" -> text("destinationWarehouseExcise.error.required")
         .transform[String](_.toUpperCase.replace(" ", ""), identity)
-        .verifying(regexpUnlessEmpty(XSS_REGEX, "destinationWarehouseExcise.error.invalidCharacter"))
-        .verifying(maxLength(16, "destinationWarehouseExcise.error.length"))
-        .verifying(inputIsValidForDestinationType(movementScenario))
+        .verifying(
+          firstError(
+            regexpUnlessEmpty(XSS_REGEX, "destinationWarehouseExcise.error.invalidCharacter"),
+            maxLength(16, "destinationWarehouseExcise.error.length"),
+            inputIsValidForDestinationType(movementScenario)
+          )
+        )
     )
 }

--- a/app/forms/sections/destination/DestinationWarehouseVatFormProvider.scala
+++ b/app/forms/sections/destination/DestinationWarehouseVatFormProvider.scala
@@ -30,8 +30,12 @@ class DestinationWarehouseVatFormProvider @Inject() extends Mappings {
   def apply(): Form[String] = {
     Form(
       "value" -> text("destinationWarehouseVat.error.required")
-        .verifying(regexpUnlessEmpty(XSS_REGEX, "destinationWarehouseVat.error.invalidCharacters"))
-        .verifying(maxLength(VAT_NUMBER_MAX_LENGTH, "destinationWarehouseVat.error.length"))
+        .verifying(
+          firstError(
+            regexpUnlessEmpty(XSS_REGEX, "destinationWarehouseVat.error.invalidCharacters"),
+            maxLength(VAT_NUMBER_MAX_LENGTH, "destinationWarehouseVat.error.length")
+          )
+        )
     )
   }
 }

--- a/app/forms/sections/firstTransporter/FirstTransporterNameFormProvider.scala
+++ b/app/forms/sections/firstTransporter/FirstTransporterNameFormProvider.scala
@@ -27,7 +27,11 @@ class FirstTransporterNameFormProvider @Inject() extends Mappings {
   def apply(): Form[String] =
     Form(
       "value" -> text("firstTransporterName.error.required")
-        .verifying(maxLength(182, "firstTransporterName.error.length"))
-        .verifying(regexpUnlessEmpty(XSS_REGEX, "firstTransporterName.error.invalidCharacter"))
+        .verifying(
+          firstError(
+            maxLength(182, "firstTransporterName.error.length"),
+            regexpUnlessEmpty(XSS_REGEX, "firstTransporterName.error.invalidCharacter")
+          )
+        )
     )
 }

--- a/app/forms/sections/guarantor/GuarantorNameFormProvider.scala
+++ b/app/forms/sections/guarantor/GuarantorNameFormProvider.scala
@@ -27,7 +27,11 @@ class GuarantorNameFormProvider @Inject() extends Mappings {
   def apply(): Form[String] =
     Form(
       "value" -> text("guarantorName.error.required")
-        .verifying(maxLength(182, "guarantorName.error.length"))
-        .verifying(regexpUnlessEmpty(XSS_REGEX, "guarantorName.error.invalidCharacter"))
+        .verifying(
+          firstError(
+            maxLength(182, "guarantorName.error.length"),
+            regexpUnlessEmpty(XSS_REGEX, "guarantorName.error.invalidCharacter")
+          )
+        )
     )
 }

--- a/app/forms/sections/journeyType/GiveInformationOtherTransportFormProvider.scala
+++ b/app/forms/sections/journeyType/GiveInformationOtherTransportFormProvider.scala
@@ -36,8 +36,12 @@ class GiveInformationOtherTransportFormProvider @Inject() extends BaseTextareaFo
               .trim,
             identity
           )
-          .verifying(maxLength(TEXTAREA_MAX_LENGTH, s"giveInformationOtherTransport.error.length"))
-          .verifying(regexpUnlessEmpty(ALPHANUMERIC_REGEX, s"giveInformationOtherTransport.error.character"))
-          .verifying(regexpUnlessEmpty(XSS_REGEX, s"giveInformationOtherTransport.error.xss"))
+          .verifying(
+            firstError(
+              maxLength(TEXTAREA_MAX_LENGTH, s"giveInformationOtherTransport.error.length"),
+              regexpUnlessEmpty(ALPHANUMERIC_REGEX, s"giveInformationOtherTransport.error.character"),
+              regexpUnlessEmpty(XSS_REGEX, s"giveInformationOtherTransport.error.xss")
+            )
+          )
     )
 }

--- a/app/forms/sections/transportArranger/TransportArrangerNameFormProvider.scala
+++ b/app/forms/sections/transportArranger/TransportArrangerNameFormProvider.scala
@@ -27,8 +27,11 @@ class TransportArrangerNameFormProvider @Inject() extends Mappings {
   def apply(): Form[String] =
     Form(
       "value" -> text("transportArrangerName.error.required")
-        .verifying(maxLength(182, "transportArrangerName.error.length"))
-        .verifying(regexpUnlessEmpty(XSS_REGEX, s"transportArrangerName.error.invalidCharacter"))
-
+        .verifying(
+          firstError(
+            maxLength(182, "transportArrangerName.error.length"),
+            regexpUnlessEmpty(XSS_REGEX, s"transportArrangerName.error.invalidCharacter")
+          )
+        )
     )
 }

--- a/app/forms/sections/transportUnit/TransportSealTypeFormProvider.scala
+++ b/app/forms/sections/transportUnit/TransportSealTypeFormProvider.scala
@@ -29,13 +29,20 @@ class TransportSealTypeFormProvider @Inject() extends BaseTextareaFormProvider[T
   def apply(): Form[TransportSealTypeModel] = Form(
     mapping(
       "value" -> text("transportSealType.sealType.error.required")
-        .verifying(maxLength(35, "transportSealType.sealType.error.length"))
-        .verifying(regexpUnlessEmpty(XSS_REGEX, s"transportSealType.sealType.error.invalid")),
+        .verifying(
+          firstError(
+            maxLength(35, "transportSealType.sealType.error.length"),
+            regexpUnlessEmpty(XSS_REGEX, s"transportSealType.sealType.error.invalid")
+          )
+        ),
       "moreInfo" -> optional(text()
-        .verifying(maxLength(TEXTAREA_MAX_LENGTH, s"transportSealType.moreInfo.error.length"))
-        .verifying(regexp(s"$ALPHANUMERIC_REGEX", s"transportSealType.moreInfo.error.invalid"))
-        .verifying(regexp(XSS_REGEX, s"transportSealType.moreInfo.error.invalidCharacter"))
-      )
+        .verifying(
+          firstError(
+            maxLength(TEXTAREA_MAX_LENGTH, s"transportSealType.moreInfo.error.length"),
+            regexp(s"$ALPHANUMERIC_REGEX", s"transportSealType.moreInfo.error.invalid"),
+            regexp(XSS_REGEX, s"transportSealType.moreInfo.error.invalidCharacter")
+          )
+        ))
     )(TransportSealTypeModel.apply)(TransportSealTypeModel.unapply)
   )
 }

--- a/app/forms/sections/transportUnit/TransportUnitGiveMoreInformationFormProvider.scala
+++ b/app/forms/sections/transportUnit/TransportUnitGiveMoreInformationFormProvider.scala
@@ -35,9 +35,13 @@ class TransportUnitGiveMoreInformationFormProvider @Inject() extends BaseTextare
             .trim,
           identity
         )
-        .verifying(maxLength(350, "transportUnitGiveMoreInformation.error.length"))
-        .verifying(regexpUnlessEmpty(ALPHANUMERIC_REGEX, s"transportUnitGiveMoreInformation.error.character"))
-        .verifying(regexpUnlessEmpty(XSS_REGEX, "transportUnitGiveMoreInformation.error.xss"))
+        .verifying(
+          firstError(
+            maxLength(350, "transportUnitGiveMoreInformation.error.length"),
+            regexpUnlessEmpty(ALPHANUMERIC_REGEX, s"transportUnitGiveMoreInformation.error.character"),
+            regexpUnlessEmpty(XSS_REGEX, "transportUnitGiveMoreInformation.error.xss")
+          )
+        )
       )
     )
 }

--- a/app/forms/sections/transportUnit/TransportUnitIdentityFormProvider.scala
+++ b/app/forms/sections/transportUnit/TransportUnitIdentityFormProvider.scala
@@ -28,8 +28,12 @@ class TransportUnitIdentityFormProvider @Inject() extends Mappings {
   def apply(transportUnitType: TransportUnitType): Form[String] =
     Form(
       "value" -> text(s"transportUnitIdentity.error.required.${transportUnitType.toString}")
-        .verifying(maxLength(35, s"transportUnitIdentity.error.length.${transportUnitType.toString}"))
-        .verifying(regexpUnlessEmpty(XSS_REGEX, s"transportUnitIdentity.error.invalidCharacters.${transportUnitType.toString}"))
+        .verifying(
+          firstError(
+            maxLength(35, s"transportUnitIdentity.error.length.${transportUnitType.toString}"),
+            regexpUnlessEmpty(XSS_REGEX, s"transportUnitIdentity.error.invalidCharacters.${transportUnitType.toString}")
+          )
+        )
     )
 
 }

--- a/test/forms/sections/journeyType/GiveInformationOtherTransportFormProviderSpec.scala
+++ b/test/forms/sections/journeyType/GiveInformationOtherTransportFormProviderSpec.scala
@@ -16,8 +16,8 @@
 
 package forms.sections.journeyType
 
+import forms.ALPHANUMERIC_REGEX
 import forms.behaviours.StringFieldBehaviours
-import forms.{ALPHANUMERIC_REGEX, XSS_REGEX}
 import play.api.data.FormError
 
 class GiveInformationOtherTransportFormProviderSpec extends StringFieldBehaviours {
@@ -91,7 +91,5 @@ class GiveInformationOtherTransportFormProviderSpec extends StringFieldBehaviour
         )
       }
     }
-
-
   }
 }

--- a/test/forms/sections/journeyType/GiveInformationOtherTransportFormProviderSpec.scala
+++ b/test/forms/sections/journeyType/GiveInformationOtherTransportFormProviderSpec.scala
@@ -87,8 +87,7 @@ class GiveInformationOtherTransportFormProviderSpec extends StringFieldBehaviour
         val result = form.bind(data)
 
         result.errors mustBe Seq(
-          FormError("value", "giveInformationOtherTransport.error.character", Seq(ALPHANUMERIC_REGEX)),
-          FormError("value", "giveInformationOtherTransport.error.xss", Seq(XSS_REGEX))
+          FormError("value", "giveInformationOtherTransport.error.character", Seq(ALPHANUMERIC_REGEX))
         )
       }
     }


### PR DESCRIPTION
All existing tests still valid. One test updated which was previously returning two errors in the expected result, now only one.