### PR TITLE
[ETFE-4232] Update the first transporter VAT view to move hint

### DIFF
--- a/app/views/sections/firstTransporter/FirstTransporterVatView.scala.html
+++ b/app/views/sections/firstTransporter/FirstTransporterVatView.scala.html
@@ -59,7 +59,6 @@
                 ),
                 legend = LegendViewModel(Text(messages("firstTransporterVat.heading"))).asPageHeading(LegendSize.Large)
             )
-            .withHint(Hint(content = Text(messages("firstTransporterVat.hint"))))
         )
 
         @continueOrExit()
@@ -73,6 +72,7 @@
             label = LabelViewModel(messages("firstTransporterVat.input.label"))
         )
         .withWidth(TwoThirds)
+        .withHint(Hint(content = Text(messages("firstTransporterVat.hint"))))
     )
 }
 


### PR DESCRIPTION
First Transporter VAT updated:
![Screenshot 2024-10-23 at 15 18 19](https://github.com/user-attachments/assets/989e87f8-00d0-496b-afc7-cfd02a354fea)

No UT changes needed as already has tests for hint. So, just need to eyeball the page hence the screenshot here ☝️ 